### PR TITLE
Have gapminders depend on conda-forge rather than pyviz/label/dev

### DIFF
--- a/gapminders/anaconda-project.yml
+++ b/gapminders/anaconda-project.yml
@@ -5,10 +5,11 @@ maintainers:
   - philippjfr
 labels:
   - panel
-  - channel_pyviz-dev
+  - channel_conda-forge
 
 channels:
-  - pyviz/label/dev
+  - conda-forge
+  - nodefaults
 
 packages: &pkgs
   - python=3.6
@@ -18,7 +19,7 @@ packages: &pkgs
   - plotly
   - holoviews=1.12.3
   - hvplot=0.4.0
-  - panel=0.6.1a3
+  - panel=0.6.2
   - param=1.9.1
   - pyviz_comms=0.7.2
   - bokeh=1.3.0


### PR DESCRIPTION
Since panel 0.6.2 has been released :)