### PR TITLE
Disable default plotly theme in gapminder demo

### DIFF
--- a/gapminders/gapminders.ipynb
+++ b/gapminders/gapminders.ipynb
@@ -30,7 +30,11 @@
     "import matplotlib.pyplot as plt\n",
     "import hvplot.pandas  # noqa: adds hvplot to pandas objects as a side effect\n",
     "\n",
-    "pn.extension('vega', 'plotly')"
+    "pn.extension('vega', 'plotly')\n",
+    "\n",
+    "# Disable default plotly theme\n",
+    "import plotly.io as pio\n",
+    "pio.templates.default = None"
    ]
   },
   {


### PR DESCRIPTION
This makes the plotly gapminder plot look like it did before plotly.py version 4.