### PR TITLE
Fix attractors thumbnail generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ jobs:
         - mv ./doc/$DIR ./tmp
         - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated
         - git checkout evaluated
-        - if ! [ -e  ./doc/$DIR ]; then rm -rf ./doc/$DIR; fi
+        - if [ -e  ./doc/$DIR ]; then rm -rf ./doc/$DIR; fi
         - mkdir ./doc/$DIR
         - mv ./tmp/* ./doc/$DIR
         - git add ./doc/$DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,8 @@ jobs:
         - mv ./doc/$DIR ./tmp
         - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated
         - git checkout evaluated
-        - if ! [ -e  ./doc/$DIR ]; then mkdir ./doc/$DIR; fi
+        - if ! [ -e  ./doc/$DIR ]; then rm -rf ./doc/$DIR; fi
+        - mkdir ./doc/$DIR
         - mv ./tmp/* ./doc/$DIR
         - git add ./doc/$DIR
         - git commit -m "adding $DIR"

--- a/attractors/anaconda-project.yml
+++ b/attractors/anaconda-project.yml
@@ -10,20 +10,16 @@ labels:
 channels: []
 
 packages: &pkgs
-  - python=3.6
-  - notebook=5.7.8
-  - ipykernel=5.1.0
-  - nomkl
-  - bokeh=1.3.4
-  - colorcet=2.0.1
-  - datashader=0.7.0
-  - holoviews=1.12.3
-  - numba=0.43.1
-  - numpy=1.16.3
-  - pandas=0.24.2
-  - panel=0.6.0
+  - python=3.7
+  - notebook=6.0
   - pyyaml=5.1
-  - tornado<6
+  - pandas=0.24
+  - numba=0.43
+  - datashader=0.7
+  - colorcet=2.0
+  - bokeh=1.3
+  - holoviews=1.12
+  - panel=0.6
 
 dependencies: *pkgs
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,7 +80,6 @@ nbsite_gallery_conf = {
             'sections': [gallery_spec(project) for project in projects],
         }
     },
-    'thumbnail_url': 'http://datashader.org/assets/images/thumbnails',
 }
 
 _NAV =  (


### PR DESCRIPTION
This PR:
 - Updates the envs so that the panel objects can thumbnail themselves. 
 - Changes the travis logic slightly to overwrite any existing evaluated contents rather than adding to what's there. Allows thumbnails to be updated (which was previously broken). 
 - Removes the link to datashader.org assets on s3. This should make it easier to keep track of what's going on and also those artifacts are no longer available since datashader now builds itself on gh-pages.