### PR TITLE
Adding Walker Lake project

### DIFF
--- a/walker_lake/Walker_Lake.ipynb
+++ b/walker_lake/Walker_Lake.ipynb
@@ -1,0 +1,350 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The Disappearing Walker Lake"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While the loss of the Aral Sea in Kazakhstan and Lake Urmia in Iran have received a lot of attention over the last few decades, this trend is a global phenomena.  Reciently a number of __[papers](https://earthobservatory.nasa.gov/IOTD/view.php?id=91921)__ have been published including one focusing on the __[Decline of the world's saline lakes](https://www.nature.com/articles/ngeo3052)__.  Many of these lakes have lost the majority of their volume over the last century, including Walker Lake (Nevada, USA) which has lost 90 percent of its volume over the last 100 years.\n",
+    "\n",
+    "The following example is intended to replicate the typical processing required in change detection studies similar to the __[Decline of the world's saline lakes](https://www.nature.com/articles/ngeo3052)__."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "import intake\n",
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import holoviews as hv\n",
+    "from holoviews import opts\n",
+    "import geoviews as gv\n",
+    "import datashader as ds\n",
+    "import cartopy.crs as ccrs\n",
+    "import pandas as pd\n",
+    "import glob\n",
+    "\n",
+    "from dask.array import PerformanceWarning\n",
+    "from colorcet import coolwarm\n",
+    "from holoviews.operation.datashader import rasterize, regrid, shade\n",
+    "\n",
+    "warnings.simplefilter('ignore', PerformanceWarning)\n",
+    "hv.extension('bokeh', width=80)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# arbitrarily choose a small memory limit (4GB) to stress the \n",
+    "# out of core processing infrastructure\n",
+    "from dask.distributed import Client\n",
+    "client = Client(memory_limit=10e10, processes=False) # Note: was 6e9 \n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Landsat Image Data\n",
+    "\n",
+    "To replicate this study, we first have to obtain the data from primary sources.  The conventional way to obtain Landsat image data is to download it through USGS's \n",
+    "__[EarthExplorer](https://earthexplorer.usgs.gov/)__ or NASA's __[Giovanni](https://giovanni.gsfc.nasa.gov/giovanni/)__, but to facilitate the example two images have been downloaded from EarthExployer and cached.  \n",
+    "\n",
+    "The two images used by the original study are LT05_L1TP_042033_19881022_20161001_01_T1 and \n",
+    "LC08_L1TP_042033_20171022_20171107_01_T1 from 1988/10/22 and 2017/10/22 respectivly.  These images contain Landsat Surface Reflectance Level-2 Science Product images."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading into xarray via ``intake``\n",
+    "\n",
+    "In the next cell, we load the Landsat-5 files into a single xarray ``DataArray`` using [intake](https://intake.readthedocs.io/en/latest/overview.html).  Data sources and caching parameters are specified in a catalog file.  Intake is optional, since any other method of creating an ``xarray.DataArray`` object would work here as well, but it makes it simpler to work with remote datasets while caching them locally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = intake.open_catalog('./catalog.yml')\n",
+    "landsat_5 = cat.landsat_5()\n",
+    "landsat_5_img = landsat_5.read_chunked()\n",
+    "landsat_5_img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "landsat_8 = cat.landsat_8()\n",
+    "landsat_8_img = landsat_8.read_chunked()\n",
+    "landsat_8_img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let us view some metadata about this ``DataArray``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"The shape of the DataArray is :\", landsat_5_img.shape)\n",
+    "print(\"With attributes:\\n \", '\\n  '.join('%s=%s'%(k,v) for k,v in landsat_5_img.attrs.items()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use this EPSG value shown above under the ``crs`` key to create a cartopy coordinate reference system that we will be using later on in this notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crs=ccrs.epsg(32611)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Computing the NDVI (1988)\n",
+    "\n",
+    "Now let us compute the [NDVI](https://en.wikipedia.org/wiki/Normalized_difference_vegetation_index) for the 1988 image. Note that we need to promote the ``DataArray`` format as returned by ``rasterio`` to an xarray ``DataSet``. This restriction should be lifted in future (see geoviews issue [209](https://github.com/pyviz/geoviews/issues/209))."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "landsat_5_img.data[landsat_5_img.data==-9999] = np.NaN  # Replace the -9999\n",
+    "ndvi5_array = (landsat_5_img[4]-landsat_5_img[3])/(landsat_5_img[4]+landsat_5_img[3])\n",
+    "ndvi5 = ndvi5_array.to_dataset(name='ndvi')[['x','y', 'ndvi']]\n",
+    "client.persist(ndvi5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Computing the NDVI (2017)\n",
+    "\n",
+    "Now we can do this for the Landsat 8 files for the 2017 image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "landsat_8_img.data[landsat_8_img.data==-9999] = np.NaN  # Replace the -9999\n",
+    "ndvi8_array = (landsat_8_img[4]-landsat_8_img[3])/(landsat_8_img[4]+landsat_8_img[3])\n",
+    "ndvi8 = ndvi8_array.to_dataset(name='ndvi')[['x','y', 'ndvi']]\n",
+    "client.persist(ndvi8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viewing change via dropdown\n",
+    "\n",
+    "Using [datashader](http://datashader.org/) together with [geoviews](http://geoviews.org/), we can now easily build an interactive visualization where we select between the 1988 and 2017 images. The use of datashader allows these images to be dynamically updated according to zoom level (Note: it can take datashader a minute to 'warm up' before it becomes fully interactive). For more information on how the dropdown widget was created using ``HoloMap``, please refer to the [HoloMap reference](http://holoviews.org/reference/containers/bokeh/HoloMap.html#bokeh-gallery-holomap)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "opts.defaults(\n",
+    "    opts.Curve(width=600, tools=['hover']),\n",
+    "    opts.Image(cmap='viridis', width=450, height=450, tools=['hover'], colorbar=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hmap = hv.HoloMap({'1988':gv.Image(ndvi5, crs=crs, vdims=['ndvi'], rtol=10), \n",
+    "                   '2017':gv.Image(ndvi8, crs=crs, vdims=['ndvi'], rtol=10)}, \n",
+    "                  kdims=['Year']).redim(x='lon', y='lat') # Mapping 'x' and 'y' from rasterio to 'lon' and 'lat'\n",
+    "rasterize(hmap)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Computing statistics and projecting display\n",
+    "\n",
+    "The rest of the notebook shows how statistical operations can reduce the dimensionality of the data that may be used to compute new features that may be used as part of an ML pipeline. \n",
+    "\n",
+    "### The mean and sum over the two time points\n",
+    "\n",
+    "The next plot (may take a minute to compute) shows the mean of the two NDVI images next to the sum of them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_avg = hmap.collapse(dimensions=['Year'], function=np.mean)\n",
+    "mean_img = gv.Image(mean_avg.data, crs=crs, kdims=['lon', 'lat'], \n",
+    "                    vdims=['ndvi']).relabel('Mean over Year')\n",
+    "\n",
+    "summed = hmap.collapse(dimensions=['Year'], function=np.sum)\n",
+    "summed_image = gv.Image(summed.data, crs=crs, kdims=['lon', 'lat'], \n",
+    "                        vdims=['ndvi']).relabel('Sum over Year')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are getting a bunch of warnings, then it is possible that your data are on a different grid. We can check whether `summed.data` is all null. If it is, then we'll need to regrid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if summed.data.ndvi.isnull().all():\n",
+    "    res = 100\n",
+    "    x = np.arange(min(ndvi5.x.min(), ndvi8.x.min()), max(ndvi5.x.max(), ndvi8.x.max()), res)\n",
+    "    y = np.arange(min(ndvi5.y.min(), ndvi8.y.min()), max(ndvi5.y.max(), ndvi8.y.max()), res)\n",
+    "    hmap = hv.HoloMap({'1988':gv.Image(ndvi5.interp(x=x, y=y), crs=crs, vdims=['ndvi']), \n",
+    "                       '2017':gv.Image(ndvi8.interp(x=x, y=y), crs=crs, vdims=['ndvi'])}, \n",
+    "                       kdims=['Year']).redim(x='lon', y='lat') # Mapping 'x' and 'y' from rasterio to 'lon' and 'lat'\n",
+    "    mean_avg = hmap.collapse(dimensions=['Year'], function=np.mean)\n",
+    "    mean_img = gv.Image(mean_avg.data, crs=crs, kdims=['lon', 'lat'], \n",
+    "                        vdims=['ndvi']).relabel('Mean over Year')\n",
+    "\n",
+    "    summed = hmap.collapse(dimensions=['Year'], function=np.sum)\n",
+    "    summed_image = gv.Image(summed.data, crs=crs, kdims=['lon', 'lat'], \n",
+    "                            vdims=['ndvi']).relabel('Sum over Year')\n",
+    "\n",
+    "rasterize(mean_img) + rasterize(summed_image)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Difference in NDVI between 1988 and 2017\n",
+    "\n",
+    "The change in Walker Lake as viewed using the NDVI can be shown by subtracting the NDVI recorded in 1988 from the NDVI recorded in 2017:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "diff = np.subtract(hmap['1988'].data, hmap['2017'].data)\n",
+    "\n",
+    "difference = gv.Image(diff, crs=crs, kdims=['lon', 'lat'], vdims=['ndvi'])\n",
+    "difference = difference.relabel('Difference in NDVI').redim(ndvi='delta_ndvi')\n",
+    "\n",
+    "rasterize(difference).redim.range(delta_ndvi=(-1.0,1.0)).opts(cmap=coolwarm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see a large change (positive delta) in the areas where there is water, indicating a reduction in the size of the lake over this time period."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Slicing across ``lon`` and ``lat``\n",
+    "\n",
+    "As a final example, we can use the ``sample`` method to slice across the difference in NDVI along (roughly) the midpoint of the latitude and the midpoint of the longitude. To do this, we define the following helper function to convert latitude/longitude into the appropriate coordinate value used by the ``DataSet``:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def from_lon_lat(x,y):\n",
+    "    return crs.transform_point(x,y, ccrs.PlateCarree())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lon_y, lat_x = from_lon_lat(-118, 39) # Longitude of -118 and Latitude of 39\n",
+    "(difference.sample(lat=lat_x) + difference.sample(lon=lon_y)).cols(1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/walker_lake/anaconda-project.yml
+++ b/walker_lake/anaconda-project.yml
@@ -1,0 +1,49 @@
+# To reproduce: install 'anaconda-project', then 'anaconda-project run'
+name: gerrymandering
+description: Analysis of NDVI over time of Walker Lake, Nevada
+maintainers:
+  - jbednar
+labels:
+  - datashader
+  - geoviews
+
+channels: [conda-forge]
+
+packages: &pkgs
+  - python=3.6
+  - notebook==6.0.3
+  - nomkl
+  - cartopy==0.17.0
+  - datashader==0.10.0
+  - fastparquet==0.3.2
+  - geoviews==1.6.6
+  - holoviews==1.12.7
+  - python-snappy=0.5.4
+  - intake==0.5.4
+  - intake-xarray==0.3.1
+  - rasterio==1.1.2
+  - dask==2.9.2
+  - s3fs==0.4.0
+  - pandas==0.25.3
+  - distributed=2.9.3
+
+dependencies: *pkgs
+
+commands:
+  notebook:
+    notebook: Walker_Lake.ipynb
+  test:
+    unix:    pytest --nbsmoke-run -k *.ipynb --ignore envs
+    windows: pytest --nbsmoke-run -k *.ipynb --ignore envs
+    env_spec: test
+  lint:
+    unix:    pytest --nbsmoke-lint -k *.ipynb --ignore envs
+    windows: pytest --nbsmoke-lint -k *.ipynb --ignore envs
+    env_spec: test
+
+env_specs:
+  default: {}
+  test:
+      packages:
+      - nbsmoke ==0.2.8
+      - pytest ==4.4.1

--- a/walker_lake/catalog.yml
+++ b/walker_lake/catalog.yml
@@ -1,0 +1,107 @@
+sources:
+  landsat_5_small:
+    description: Small version of Landsat 5 Surface Reflectance Level-2 Science Product.
+    driver: rasterio
+    cache:
+      - argkey: urlpath
+        regex: 'earth-data/landsat'
+        type: file
+    args:
+      urlpath: 's3://earth-data/landsat/small/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band{band:d}.tif'
+      chunks:
+        band: 1
+        x: 50
+        y: 50
+      concat_dim: band
+      storage_options: {'anon': True, 'region_name':'us-east-1'}
+    metadata:
+      plots:
+        band_image:
+          kind: 'image'
+          x: 'x'
+          y: 'y'
+          groupby: 'band'
+          rasterize: True
+          width: 400
+          dynamic: False
+          
+  landsat_8_small:
+    description: Small version of Landsat 8 Surface Reflectance Level-2 Science Product.
+    driver: rasterio
+    cache:
+      - argkey: urlpath
+        regex: 'earth-data/landsat'
+        type: file
+    args:
+      urlpath: 's3://earth-data/landsat/small/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band{band:d}.tif'
+      chunks:
+        band: 1
+        x: 50
+        y: 50
+      concat_dim: band
+      storage_options: {'anon': True, 'region_name':'us-east-1'}  
+   
+  landsat_5:
+    description: Images contain Landsat 5 Surface Reflectance Level-2 Science Product.
+    driver: rasterio
+    cache:
+      - argkey: urlpath
+        regex: 'earth-data/landsat'
+        type: file
+    args:
+      urlpath: 's3://earth-data/landsat/LT05_L1TP_042033_19881022_20161001_01_T1_sr_band{band:d}.tif'
+      chunks:
+        band: 1
+        x: 256
+        y: 256
+      concat_dim: band
+      storage_options: {'anon': True, 'region_name':'us-east-1'}
+    metadata:
+      plots:
+        band_image:
+          kind: 'image'
+          x: 'x'
+          y: 'y'
+          groupby: 'band'
+          rasterize: True
+          width: 400
+
+
+  landsat_8:
+    description: Images contain Landsat 8 Surface Reflectance Level-2 Science Product.
+    driver: rasterio
+    cache:
+      - argkey: urlpath
+        regex: 'earth-data/landsat'
+        type: file
+    args:
+      urlpath: 's3://earth-data/landsat/LC08_L1TP_042033_20171022_20171107_01_T1_sr_band{band:d}.tif'
+      chunks:
+        band: 1
+        x: 256
+        y: 256
+      concat_dim: band
+      storage_options: {'anon': True, 'region_name':'us-east-1'}
+
+  google_landsat_band:
+    description: Landsat bands from Google Cloud Storage
+    driver: rasterio
+    parameters:
+      path:
+        description: landsat path
+        type: int
+      row:
+        description: landsat row
+        type: int
+      product_id:
+        description: landsat file id
+        type: str
+      band:
+        description: band
+        type: int
+    args:
+      urlpath: https://storage.googleapis.com/gcp-public-data-landsat/LC08/01/{{ '%03d' % path }}/{{ '%03d' % row }}/{{ product_id }}/{{ product_id }}_B{{ band }}.TIF
+      chunks:
+        band: 1
+        x: 256
+        y: 256


### PR DESCRIPTION
This project is the [Walker Lake example](https://earthml.holoviz.org/topics/Walker_Lake.html) from earthml.holoviz.org. This project both updates the necessary dependencies, makes a number of fixes needed for reproducibility and makes sure only the dependencies that are needed are listed (on contrast to the full EarthML environment that no longer works properly).

I don't think this project should be more than an HTML build of the notebook: a read-only notebook deployment would take quite a long time to run and I am not sure how much more useful it is than a simple snapshot.

### FIXES:

- [x] The AWS S3 region wasn't specified which meant intake could not reliably fetch the necessary data.
- [x] Pinned `distributed` to `2.9.3` as the new `2.10.0` version causes the initial (datashaded) HoloMap to hang.
- [x] Silenced the dask performance warnings issued while rechunking.

### TODO:

- [ ] Investigate the `distributed 2.10.0` issue further.
- [ ] Remove dependence on EPSG server. There were problems communicating with the server earlier this week and it would be good to remove a potential point of failure.
- [ ] Capture the full lock of the project environment.
- [ ] Hook up with the `landsat5_small` and `landsat8_small`  datasets for testing.
- [ ] Add a warning to the top of the notebook stating how long it should take to run the whole notebook?