### PR TITLE
Move classes from .ipynb into attractors.py

### DIFF
--- a/attractors/attractors.py
+++ b/attractors/attractors.py
@@ -14,7 +14,6 @@ from collections import OrderedDict
 import numpy as np
 import pandas as pd
 import param
-import panel as pn
 import inspect
 import yaml
 
@@ -51,7 +50,7 @@ def trajectory(fn, x0, y0, a, b=None, c=None, d=None, e=None, f=None, n=1000000)
 
 class Attractor(param.Parameterized):
     """Base class for a Parameterized object that can evaluate an attractor trajectory"""
-    
+
     x = param.Number(0,  softbounds=(-2, 2), doc="Starting x value", precedence=-1)
     y = param.Number(0,  softbounds=(-2, 2), doc="Starting y value", precedence=-1)
 
@@ -64,16 +63,16 @@ class Attractor(param.Parameterized):
 
     equations = param.List([], class_=str, precedence=-1, readonly=True, doc="""
         LaTeX-formatted list of equations""")
-    
+
     __abstract = True
-    
+
     def __call__(self, n, x=None, y=None):
         """Return a dataframe with *n* points"""
         if x is not None: self.x=x
         if y is not None: self.y=y
         args = [getattr(self,p) for p in self.sig()]
         return trajectory(self.fn, *args, n=n)
-    
+
     def vals(self):
         return [self.__class__.name] + [self.colormap] + [getattr(self,p) for p in self.sig()]
 
@@ -91,9 +90,9 @@ class FourParamAttractor(Attractor):
 
 
 class Clifford(FourParamAttractor):
-    equations = param.List([r'$x_{n+1} = \sin\ ay_n + c\ \cos\ ax_n$', 
+    equations = param.List([r'$x_{n+1} = \sin\ ay_n + c\ \cos\ ax_n$',
                             r'$y_{n+1} = \sin\ bx_n + d\ \cos\ by_n$'])
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, c, d, *o):
@@ -102,54 +101,54 @@ class Clifford(FourParamAttractor):
 
 
 class De_Jong(FourParamAttractor):
-    equations = param.List([r'$x_{n+1} = \sin\ ay_n - c\ \cos\ bx_n$', 
+    equations = param.List([r'$x_{n+1} = \sin\ ay_n - c\ \cos\ bx_n$',
                             r'$y_{n+1} = \sin\ cx_n - d\ \cos\ dy_n$'])
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, c, d, *o):
         return sin(a * y) - cos(b * x), \
                sin(c * x) - cos(d * y)
 
-    
+
 class Svensson(FourParamAttractor):
-    equations = param.List([r'$x_{n+1} = d\ \sin\ ax_n - \sin\ by_n$', 
+    equations = param.List([r'$x_{n+1} = d\ \sin\ ax_n - \sin\ by_n$',
                             r'$y_{n+1} = c\ \cos\ ax_n + \cos\ by_n$'])
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, c, d, *o):
         return d * sin(a * x) - sin(b * y), \
                c * cos(a * x) + cos(b * y)
 
-    
+
 class Fractal_Dream(Attractor):
-    equations = param.List([r'$x_{n+1} = \sin\ by_n + c\ \sin\ bx_n$', 
+    equations = param.List([r'$x_{n+1} = \sin\ by_n + c\ \sin\ bx_n$',
                             r'$y_{n+1} = \sin\ ax_n + d\ \sin\ ay_n$'])
-    
+
     c = param.Number(1.15, softbounds=(-0.5, 1.5), doc="Attractor parameter c")
     d = param.Number(2.34, softbounds=(-0.5, 1.5), doc="Attractor parameter d")
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, c, d, *o):
         return sin(b*y)+c*sin(b*x), \
                sin(a*x)+d*sin(a*y)
 
-    
+
 class Bedhead(Attractor):
-    equations = param.List([r'$x_{n+1} = y_n\ \sin\ \frac{x_ny_n}{b} + \cos(ax_n-y_n)$', 
+    equations = param.List([r'$x_{n+1} = y_n\ \sin\ \frac{x_ny_n}{b} + \cos(ax_n-y_n)$',
                             r'$y_{n+1} = x_n+\frac{\sin\ y_n}{b}$'])
-    
+
     a = param.Number(0.64, bounds=(-1, 1))
     b = param.Number(0.76, bounds=(-1, 1))
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, *o):
         return y*sin(x*y/b) + cos(a*x-y), \
                x + sin(y)/b
-    
+
     def __call__(self, n):
         # Avoid interactive divide-by-zero errors for b
         epsilon = 3*np.finfo(float).eps
@@ -157,11 +156,11 @@ class Bedhead(Attractor):
             self.b = epsilon
         return super(Bedhead,self).__call__(n)
 
-    
+
 class Hopalong1(Attractor):
-    equations = param.List([r'$x_{n+1} = y_n-\mathrm{sgn}(x_n)\sqrt{\left|\ bx_n-c\ \right|}$', 
+    equations = param.List([r'$x_{n+1} = y_n-\mathrm{sgn}(x_n)\sqrt{\left|\ bx_n-c\ \right|}$',
                             r'$y_{n+1} = a-x_n$'])
-    
+
     a = param.Number(9.8, bounds=(0, 10))
     b = param.Number(4.1, bounds=(0, 10))
     c = param.Number(3.8, bounds=(0, 10), doc="Attractor parameter c")
@@ -174,9 +173,9 @@ class Hopalong1(Attractor):
 
 
 class Hopalong2(Hopalong1):
-    equations = param.List([r'$x_{n+1} = y_n-1-\mathrm{sgn}(x_n-1)\sqrt{\left|\ bx_n-1-c\ \right|}$', 
+    equations = param.List([r'$x_{n+1} = y_n-1-\mathrm{sgn}(x_n-1)\sqrt{\left|\ bx_n-1-c\ \right|}$',
                             r'$y_{n+1} = a-x_n-1$'])
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, c, *o):
@@ -190,15 +189,15 @@ def G(x, mu):
 
 class Gumowski_Mira(Attractor):
     equations = param.List([r'$G(x) = \mu x + \frac{2(1-\mu)x^2}{1+x^2}$',
-                            r'$x_{n+1} = y_n + ay_n(1-by_n^2) + G(x_n)$', 
+                            r'$x_{n+1} = y_n + ay_n(1-by_n^2) + G(x_n)$',
                             r'$y_{n+1} = -x_n + G(x_{n+1})$'])
-    
+
     x = param.Number(0,    softbounds=(-20, 20), doc="Starting x value", precedence=0.1)
     y = param.Number(0,    softbounds=(-20, 20), doc="Starting y value", precedence=0.1)
     a = param.Number(0.64, softbounds=( -1,  1))
     b = param.Number(0.76, softbounds=( -1,  1))
     mu = param.Number(0.6, softbounds=( -2,  2), doc="Attractor parameter mu")
-    
+
     @staticmethod
     @jit(nopython=True)
     def fn(x, y, a, b, mu, *o):
@@ -221,14 +220,14 @@ class Symmetric_Icon(Attractor):
         zzbar = x*x + y*y
         p = a*zzbar + l
         zreal, zimag = x, y
-    
+
         for i in range(1, d-1):
             za, zb = zreal * x - zimag * y, zimag * x + zreal * y
             zreal, zimag = za, zb
-    
+
         zn = x*zreal - y*zimag
         p += b*zn
-    
+
         return p*x + g*zreal - om*y, \
                p*y - g*zimag + om*x
 
@@ -236,13 +235,14 @@ class Symmetric_Icon(Attractor):
 class ParameterSets(param.Parameterized):
     """
     Allows selection from sets of pre-defined parameters saved in YAML.
-    
+
     Assumes the YAML file returns a list of groups of values.
     """
 
     examples_filename = param.Filename("attractors.yml")
+    current           = param.Callable(lambda: None, precedence=-1)
     remember_this_one = param.Action(lambda x: x._remember())
-    
+
     load      = param.Action(lambda x: x._load())
     randomize = param.Action(lambda x: x._randomize())
     sort      = param.Action(lambda x: x._sort())
@@ -252,30 +252,31 @@ class ParameterSets(param.Parameterized):
     def __init__(self,**params):
         super(ParameterSets,self).__init__(**params)
         self._load()
-        
+
         self.attractors = OrderedDict(sorted([(k,v(name=k + " parameters")) for k,v in concrete_descendents(Attractor).items()]))
         for k in self.attractors:
             self.attractor(k, *self.args(k)[0])
 
     def _load(self):
-        with open(self.examples_filename,"r") as f: 
+        with open(self.examples_filename,"r") as f:
             vals = yaml.safe_load(f)
             assert(vals and len(vals)>0)
             self.param.example.objects=vals
             self.example = vals[0]
 
     def _save(self):
-        with open(self.examples_filename,"w") as f: 
+        with open(self.examples_filename,"w") as f:
             yaml.dump(self.param.example.objects,f)
 
     def __call__(self):        return self.example
     def _randomize(self):      npr.shuffle(self.param.example.objects)
     def _sort(self):            self.param.example.objects = list(sorted(self.param.example.objects))
     def _add_item(self, item): self.param.example.objects += [item] ; self.example=item
+
     def _remember(self):
-        vals = ats.attractor_type.vals() # forward reference
+        vals = self.current().vals()
         self._add_item(vals)
-        
+
     def args(self, name):
         return [v[1:] for v in self.param.example.objects if v[0]==name]
 

--- a/attractors/attractors.py
+++ b/attractors/attractors.py
@@ -1,0 +1,287 @@
+"""
+Support for working with a family of attractor equations (https://en.wikipedia.org/wiki/Attractor#Strange_attractor)
+
+Each attractor has:
+- Executable Python code for calculating trajectories, optimized using Numba (numba.pydata.org)
+- Readable equations displayable with KaTeX
+- Examples of interesting patterns stored in a separate attractors.yml file
+
+Support is provided for reading the attractors.yml file and working with the examples in it.
+"""
+
+from collections import OrderedDict
+
+import numpy as np
+import pandas as pd
+import param
+import panel as pn
+import inspect
+import yaml
+
+from numba import jit
+from numpy import sin, cos, sqrt, fabs
+from param import concrete_descendents
+
+import numpy.random as npr
+npr.seed(12)
+
+
+@jit(nopython=True)
+def trajectory_coords(fn, x0, y0, a, b, c, d, e, f, n):
+    """
+    Given an attractor fn with up to six parameters a-e, compute n trajectory points
+    (starting from x0,y0). Numba-optimized to run at machine-code speeds.
+    """
+    x, y = np.zeros(n), np.zeros(n)
+    x[0], y[0] = x0, y0
+    for i in np.arange(n-1):
+        x[i+1], y[i+1] = fn(x[i], y[i], a, b, c, d, e, f)
+    return x, y
+
+
+def trajectory(fn, x0, y0, a, b=None, c=None, d=None, e=None, f=None, n=1000000):
+    """
+    Given an attractor fn with up to six parameters a-e, compute n trajectory points
+    (starting from x0,y0) and return as a Pandas dataframe with columns x,y.
+    """
+    xs, ys = trajectory_coords(fn, x0, y0, a, b, c, d, e, f, n)
+    return pd.DataFrame(dict(x=xs,y=ys))
+
+
+
+class Attractor(param.Parameterized):
+    """Base class for a Parameterized object that can evaluate an attractor trajectory"""
+    
+    x = param.Number(0,  softbounds=(-2, 2), doc="Starting x value", precedence=-1)
+    y = param.Number(0,  softbounds=(-2, 2), doc="Starting y value", precedence=-1)
+
+    a = param.Number(1.7, bounds=(-3, 3), doc="Attractor parameter a")
+    b = param.Number(1.7, bounds=(-3, 3), doc="Attractor parameter b")
+
+    colormap = param.ObjectSelector("kgy", precedence=0.7, check_on_set=False,
+        doc="Palette of colors to use for plotting",
+        objects=['bgy', 'bmw', 'bgyw', 'bmy', 'fire', 'gray', 'kgy', 'kbc', 'viridis', 'inferno'])
+
+    equations = param.List([], class_=str, precedence=-1, readonly=True, doc="""
+        LaTeX-formatted list of equations""")
+    
+    __abstract = True
+    
+    def __call__(self, n, x=None, y=None):
+        """Return a dataframe with *n* points"""
+        if x is not None: self.x=x
+        if y is not None: self.y=y
+        args = [getattr(self,p) for p in self.sig()]
+        return trajectory(self.fn, *args, n=n)
+    
+    def vals(self):
+        return [self.__class__.name] + [self.colormap] + [getattr(self,p) for p in self.sig()]
+
+    def sig(self):
+        """Returns the calling signature expected by this attractor function"""
+        return list(inspect.signature(self.fn).parameters.keys())[:-1]
+
+
+class FourParamAttractor(Attractor):
+    """Base class for most four-parameter attractors"""
+    c = param.Number(0.6, softbounds=(-3, 3), doc="Attractor parameter c")
+    d = param.Number(1.2, softbounds=(-3, 3), doc="Attractor parameter d")
+
+    __abstract = True
+
+
+class Clifford(FourParamAttractor):
+    equations = param.List([r'$x_{n+1} = \sin\ ay_n + c\ \cos\ ax_n$', 
+                            r'$y_{n+1} = \sin\ bx_n + d\ \cos\ by_n$'])
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, c, d, *o):
+        return sin(a * y) + c * cos(a * x), \
+               sin(b * x) + d * cos(b * y)
+
+
+class De_Jong(FourParamAttractor):
+    equations = param.List([r'$x_{n+1} = \sin\ ay_n - c\ \cos\ bx_n$', 
+                            r'$y_{n+1} = \sin\ cx_n - d\ \cos\ dy_n$'])
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, c, d, *o):
+        return sin(a * y) - cos(b * x), \
+               sin(c * x) - cos(d * y)
+
+    
+class Svensson(FourParamAttractor):
+    equations = param.List([r'$x_{n+1} = d\ \sin\ ax_n - \sin\ by_n$', 
+                            r'$y_{n+1} = c\ \cos\ ax_n + \cos\ by_n$'])
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, c, d, *o):
+        return d * sin(a * x) - sin(b * y), \
+               c * cos(a * x) + cos(b * y)
+
+    
+class Fractal_Dream(Attractor):
+    equations = param.List([r'$x_{n+1} = \sin\ by_n + c\ \sin\ bx_n$', 
+                            r'$y_{n+1} = \sin\ ax_n + d\ \sin\ ay_n$'])
+    
+    c = param.Number(1.15, softbounds=(-0.5, 1.5), doc="Attractor parameter c")
+    d = param.Number(2.34, softbounds=(-0.5, 1.5), doc="Attractor parameter d")
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, c, d, *o):
+        return sin(b*y)+c*sin(b*x), \
+               sin(a*x)+d*sin(a*y)
+
+    
+class Bedhead(Attractor):
+    equations = param.List([r'$x_{n+1} = y_n\ \sin\ \frac{x_ny_n}{b} + \cos(ax_n-y_n)$', 
+                            r'$y_{n+1} = x_n+\frac{\sin\ y_n}{b}$'])
+    
+    a = param.Number(0.64, bounds=(-1, 1))
+    b = param.Number(0.76, bounds=(-1, 1))
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, *o):
+        return y*sin(x*y/b) + cos(a*x-y), \
+               x + sin(y)/b
+    
+    def __call__(self, n):
+        # Avoid interactive divide-by-zero errors for b
+        epsilon = 3*np.finfo(float).eps
+        if -epsilon < self.b < epsilon:
+            self.b = epsilon
+        return super(Bedhead,self).__call__(n)
+
+    
+class Hopalong1(Attractor):
+    equations = param.List([r'$x_{n+1} = y_n-\mathrm{sgn}(x_n)\sqrt{\left|\ bx_n-c\ \right|}$', 
+                            r'$y_{n+1} = a-x_n$'])
+    
+    a = param.Number(9.8, bounds=(0, 10))
+    b = param.Number(4.1, bounds=(0, 10))
+    c = param.Number(3.8, bounds=(0, 10), doc="Attractor parameter c")
+
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, c, *o):
+        return y - sqrt(fabs(b * x - c)) * np.sign(x), \
+               a - x
+
+
+class Hopalong2(Hopalong1):
+    equations = param.List([r'$x_{n+1} = y_n-1-\mathrm{sgn}(x_n-1)\sqrt{\left|\ bx_n-1-c\ \right|}$', 
+                            r'$y_{n+1} = a-x_n-1$'])
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, c, *o):
+        return y - 1.0 - sqrt(fabs(b * x - 1.0 - c)) * np.sign(x - 1.0), \
+               a - x - 1.0
+
+
+@jit(nopython=True)
+def G(x, mu):
+    return mu * x + 2 * (1 - mu) * x**2 / (1.0 + x**2)
+
+class Gumowski_Mira(Attractor):
+    equations = param.List([r'$G(x) = \mu x + \frac{2(1-\mu)x^2}{1+x^2}$',
+                            r'$x_{n+1} = y_n + ay_n(1-by_n^2) + G(x_n)$', 
+                            r'$y_{n+1} = -x_n + G(x_{n+1})$'])
+    
+    x = param.Number(0,    softbounds=(-20, 20), doc="Starting x value", precedence=0.1)
+    y = param.Number(0,    softbounds=(-20, 20), doc="Starting y value", precedence=0.1)
+    a = param.Number(0.64, softbounds=( -1,  1))
+    b = param.Number(0.76, softbounds=( -1,  1))
+    mu = param.Number(0.6, softbounds=( -2,  2), doc="Attractor parameter mu")
+    
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, mu, *o):
+        xn = y + a*(1 - b*y**2)*y  +  G(x, mu)
+        yn = -x + G(xn, mu)
+        return xn, yn
+
+
+class Symmetric_Icon(Attractor):
+    a = param.Number(0.6, softbounds=(-20, 20),  bounds=(None,None), doc="Attractor parameter alpha")
+    b = param.Number(1.2, softbounds=(-20, 20),  bounds=(None,None), doc="Attractor parameter beta")
+    g = param.Number(0.6, softbounds=(-1,   1),  bounds=(None,None), doc="Attractor parameter gamma")
+    om= param.Number(1.2, softbounds=(-0.2, 0.2),bounds=(None,None), doc="Attractor parameter omega")
+    l = param.Number(0.6, softbounds=(-3,   3),  bounds=(None,None), doc="Attractor parameter lambda")
+    d = param.Number(1.2, softbounds=( 1,  20),  bounds=(None,None), doc="Attractor parameter degree")
+
+    @staticmethod
+    @jit(nopython=True)
+    def fn(x, y, a, b, g, om, l, d, *o):
+        zzbar = x*x + y*y
+        p = a*zzbar + l
+        zreal, zimag = x, y
+    
+        for i in range(1, d-1):
+            za, zb = zreal * x - zimag * y, zimag * x + zreal * y
+            zreal, zimag = za, zb
+    
+        zn = x*zreal - y*zimag
+        p += b*zn
+    
+        return p*x + g*zreal - om*y, \
+               p*y - g*zimag + om*x
+
+
+class ParameterSets(param.Parameterized):
+    """
+    Allows selection from sets of pre-defined parameters saved in YAML.
+    
+    Assumes the YAML file returns a list of groups of values.
+    """
+
+    examples_filename = param.Filename("attractors.yml")
+    remember_this_one = param.Action(lambda x: x._remember())
+    
+    load      = param.Action(lambda x: x._load())
+    randomize = param.Action(lambda x: x._randomize())
+    sort      = param.Action(lambda x: x._sort())
+    save      = param.Action(lambda x: x._save(), precedence=0.8)
+    example   = param.Selector(objects=[[]], precedence=-1)
+
+    def __init__(self,**params):
+        super(ParameterSets,self).__init__(**params)
+        self._load()
+        
+        self.attractors = OrderedDict(sorted([(k,v(name=k + " parameters")) for k,v in concrete_descendents(Attractor).items()]))
+        for k in self.attractors:
+            self.attractor(k, *self.args(k)[0])
+
+    def _load(self):
+        with open(self.examples_filename,"r") as f: 
+            vals = yaml.safe_load(f)
+            assert(vals and len(vals)>0)
+            self.param.example.objects=vals
+            self.example = vals[0]
+
+    def _save(self):
+        with open(self.examples_filename,"w") as f: 
+            yaml.dump(self.param.example.objects,f)
+
+    def __call__(self):        return self.example
+    def _randomize(self):      npr.shuffle(self.param.example.objects)
+    def _sort(self):            self.param.example.objects = list(sorted(self.param.example.objects))
+    def _add_item(self, item): self.param.example.objects += [item] ; self.example=item
+    def _remember(self):
+        vals = ats.attractor_type.vals() # forward reference
+        self._add_item(vals)
+        
+    def args(self, name):
+        return [v[1:] for v in self.param.example.objects if v[0]==name]
+
+    def attractor(self, name, *args):
+        """Factory function to return an Attractor object with the given name and arg values"""
+        attractor = self.attractors[name]
+        fn_params = ['colormap'] + attractor.sig()
+        attractor.param.set_param(**dict(zip(fn_params, args)))
+        return attractor

--- a/attractors/attractors_panel.ipynb
+++ b/attractors/attractors_panel.ipynb
@@ -8,13 +8,20 @@
     "\n",
     "## Panel/Numba/Datashader Strange Attractors app\n",
     "\n",
-    "[Strange attractors](attractors.ipynb) are a type of iterative equation that traces the path of a particle through a 2D space, forming interesting patterns in the trajectories. \n",
+    "[Strange attractors](attractors.ipynb) are a type of iterative equation that traces the path of a particle through a 2D space, forming interesting patterns in the trajectories. The patterns differ depending on which sets of equations are used and which parameter values are selected for those equations.\n",
     "\n",
-    "There are many attractor families determined by a set of attractor equations, each with associated numerical parameters. To make the parameter space easy to explore, we'll build an app that selects between the attractor families and allows you to manipulate their parameter values. Using this app requires `conda install -c pyviz/label/dev panel param datashader` and a live, running Python process (not just a static web page or anaconda.org viewer). You may wish to check out the much simpler [Clifford-only app](clifford_panel.ipynb) first, to understand the basic structure of an app and of how to compute an attractor.\n",
+    "To make the parameter spaces easy to explore, we'll build a web-based application using [Panel](https://panel.holoviz.org) to select between the attractor families, adjust the parameter values for that type of attractor, and see the results rendered using [Datashader](https://datashader.org). Using this app requires `conda install -c pyviz panel datashader` and a live, running Python process, not just a static web page or anaconda.org viewer. \n",
+    "\n",
+    "This dashboard code also functions as an example of how to build a Panel application for working with an arbitrarily large family of Python objects organized into a class hierarchy, without depending on the details of that structure and without that code depending on any GUI libraries. In this approach, each object defines its own parameters in a GUI-independent way, but then Panel can access this information and construct appropriate widgets to provide interactive control of the values. This approach can allow the same codebase be used in a GUI with full interactivity while also supporting non-GUI command-line, batch, or headless usage. \n",
+    "\n",
+    "If you aren't familiar with Panel, you may wish to check out the much simpler [Clifford-only app](clifford_panel.ipynb) first, to understand the basic structure of an app and of how to compute an attractor.\n",
+    "\n",
     "\n",
     "## Attractor definitions\n",
     "\n",
-    "First, we'll define a function for collecting the values of any attractor function with up to six parameters, using [Numba](http://numba.pydata.org) to make it 50X faster than bare [Python](http://python.org):"
+    "Here, we'll make use of a family of attractors whose code is defined in the separate file [attractors.py](attractors.py), currently including classes for Clifford, De Jong, Svensson, Fractal Dream, Bedhead, Hopalong1, Hopalong2, Gumowski Mira, and Symmetric Icon attractors. That module also provides support for working with a separate YAML-format list of examples of each type of attractor, in [attractors.yml](attractors.yml).\n",
+    "\n",
+    "Each attractor family is a subclass of the Attractor class, capturing the attractor equations as runnable Python code, the equations in LaTeX for for displaying, the parameters of the equations, and their expected ranges of values:"
    ]
   },
   {
@@ -23,239 +30,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np, pandas as pd\n",
-    "from numba import jit\n",
+    "import attractors as at\n",
     "\n",
-    "@jit(nopython=True)\n",
-    "def trajectory_coords(fn, x0, y0, a, b, c, d, e, f, n):\n",
-    "    x, y = np.zeros(n), np.zeros(n)\n",
-    "    x[0], y[0] = x0, y0\n",
-    "    for i in np.arange(n-1):\n",
-    "        x[i+1], y[i+1] = fn(x[i], y[i], a, b, c, d, e, f)\n",
-    "    return x, y\n",
-    "\n",
-    "def trajectory(fn, x0, y0, a, b=None, c=None, d=None, e=None, f=None, n=1000000):\n",
-    "    xs, ys = trajectory_coords(fn, x0, y0, a, b, c, d, e, f, n)\n",
-    "    return pd.DataFrame(dict(x=xs,y=ys))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we'll define a class hierarchy to provide a shared interface for the various attractor types:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import param, panel as pn, inspect\n",
-    "pn.extension('katex')\n",
-    "\n",
-    "class Attractor(param.Parameterized):\n",
-    "    \"\"\"A parameterized object that can evaluate an attractor trajectory\"\"\"\n",
-    "    \n",
-    "    x = param.Number(0,  softbounds=(-2, 2), doc=\"Starting x value\", precedence=-1)\n",
-    "    y = param.Number(0,  softbounds=(-2, 2), doc=\"Starting y value\", precedence=-1)\n",
-    "\n",
-    "    a = param.Number(1.7, bounds=(-3, 3), doc=\"Attractor parameter a\")\n",
-    "    b = param.Number(1.7, bounds=(-3, 3), doc=\"Attractor parameter b\")\n",
-    "\n",
-    "    colormap = param.ObjectSelector(\"kgy\", precedence=0.7, check_on_set=False,\n",
-    "        objects=['bgy', 'bmw', 'bgyw', 'bmy', 'fire', 'gray', 'kgy', 'kbc', 'viridis', 'inferno'])\n",
-    "\n",
-    "    equations = param.List([], class_=str, precedence=-1, readonly=True)\n",
-    "    \n",
-    "    __abstract = True\n",
-    "    \n",
-    "    def __call__(self, n, x=None, y=None):\n",
-    "        \"\"\"Return a dataframe with *n* points\"\"\"\n",
-    "        if x is not None: self.x=x\n",
-    "        if y is not None: self.y=y\n",
-    "        args = [getattr(self,p) for p in self.sig()]\n",
-    "        return trajectory(self.fn, *args, n=n)\n",
-    "    \n",
-    "    def vals(self):\n",
-    "        return [self.__class__.name] + [self.colormap] + [getattr(self,p) for p in self.sig()]\n",
-    "\n",
-    "    def sig(self):\n",
-    "        \"\"\"Returns the calling signature expected by this attractor function\"\"\"\n",
-    "        return list(inspect.signature(self.fn).parameters.keys())[:-1]\n",
-    "    \n",
-    "class FourParamAttractor(Attractor):\n",
-    "    \"\"\"Base class for most four-parameter attractors\"\"\"\n",
-    "    c = param.Number(0.6, softbounds=(-3, 3), doc=\"Attractor parameter c\")\n",
-    "    d = param.Number(1.2, softbounds=(-3, 3), doc=\"Attractor parameter d\")\n",
-    "\n",
-    "    __abstract = True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Each type of attractor is then a subclass in this hierarchy, capturing the attractor equations (both in LaTeX form for printing and as a runnable Python function), their parameters, and their expected ranges of values:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from numpy import sin, cos, sqrt, fabs\n",
-    "\n",
-    "class Clifford(FourParamAttractor):\n",
-    "    equations = param.List([r'$x_{n+1} = \\sin\\ ay_n + c\\ \\cos\\ ax_n$', \n",
-    "                            r'$y_{n+1} = \\sin\\ bx_n + d\\ \\cos\\ by_n$'])\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, c, d, *o):\n",
-    "        return sin(a * y) + c * cos(a * x), \\\n",
-    "               sin(b * x) + d * cos(b * y)\n",
-    "\n",
-    "\n",
-    "class De_Jong(FourParamAttractor):\n",
-    "    equations = param.List([r'$x_{n+1} = \\sin\\ ay_n - c\\ \\cos\\ bx_n$', \n",
-    "                            r'$y_{n+1} = \\sin\\ cx_n - d\\ \\cos\\ dy_n$'])\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, c, d, *o):\n",
-    "        return sin(a * y) - cos(b * x), \\\n",
-    "               sin(c * x) - cos(d * y)\n",
-    "\n",
-    "    \n",
-    "class Svensson(FourParamAttractor):\n",
-    "    equations = param.List([r'$x_{n+1} = d\\ \\sin\\ ax_n - \\sin\\ by_n$', \n",
-    "                            r'$y_{n+1} = c\\ \\cos\\ ax_n + \\cos\\ by_n$'])\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, c, d, *o):\n",
-    "        return d * sin(a * x) - sin(b * y), \\\n",
-    "               c * cos(a * x) + cos(b * y)\n",
-    "\n",
-    "    \n",
-    "class Fractal_Dream(Attractor):\n",
-    "    equations = param.List([r'$x_{n+1} = \\sin\\ by_n + c\\ \\sin\\ bx_n$', \n",
-    "                            r'$y_{n+1} = \\sin\\ ax_n + d\\ \\sin\\ ay_n$'])\n",
-    "    \n",
-    "    c = param.Number(1.15, softbounds=(-0.5, 1.5), doc=\"Attractor parameter c\")\n",
-    "    d = param.Number(2.34, softbounds=(-0.5, 1.5), doc=\"Attractor parameter d\")\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, c, d, *o):\n",
-    "        return sin(b*y)+c*sin(b*x), \\\n",
-    "               sin(a*x)+d*sin(a*y)\n",
-    "\n",
-    "    \n",
-    "class Bedhead(Attractor):\n",
-    "    equations = param.List([r'$x_{n+1} = y_n\\ \\sin\\ \\frac{x_ny_n}{b} + \\cos(ax_n-y_n)$', \n",
-    "                            r'$y_{n+1} = x_n+\\frac{\\sin\\ y_n}{b}$'])\n",
-    "    \n",
-    "    a = param.Number(0.64, bounds=(-1, 1))\n",
-    "    b = param.Number(0.76, bounds=(-1, 1))\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, *o):\n",
-    "        return y*sin(x*y/b) + cos(a*x-y), \\\n",
-    "               x + sin(y)/b\n",
-    "    \n",
-    "    def __call__(self, n):\n",
-    "        # Avoid interactive divide-by-zero errors for b\n",
-    "        epsilon = 3*np.finfo(float).eps\n",
-    "        if -epsilon < self.b < epsilon:\n",
-    "            self.b = epsilon\n",
-    "        return super(Bedhead,self).__call__(n)\n",
-    "\n",
-    "    \n",
-    "class Hopalong1(Attractor):\n",
-    "    equations = param.List([r'$x_{n+1} = y_n-\\mathrm{sgn}(x_n)\\sqrt{\\left|\\ bx_n-c\\ \\right|}$', \n",
-    "                            r'$y_{n+1} = a-x_n$'])\n",
-    "    \n",
-    "    a = param.Number(9.8, bounds=(0, 10))\n",
-    "    b = param.Number(4.1, bounds=(0, 10))\n",
-    "    c = param.Number(3.8, bounds=(0, 10), doc=\"Attractor parameter c\")\n",
-    "\n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, c, *o):\n",
-    "        return y - sqrt(fabs(b * x - c)) * np.sign(x), \\\n",
-    "               a - x\n",
-    "\n",
-    "\n",
-    "class Hopalong2(Hopalong1):\n",
-    "    equations = param.List([r'$x_{n+1} = y_n-1-\\mathrm{sgn}(x_n-1)\\sqrt{\\left|\\ bx_n-1-c\\ \\right|}$', \n",
-    "                            r'$y_{n+1} = a-x_n-1$'])\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, c, *o):\n",
-    "        return y - 1.0 - sqrt(fabs(b * x - 1.0 - c)) * np.sign(x - 1.0), \\\n",
-    "               a - x - 1.0\n",
-    "\n",
-    "\n",
-    "@jit(nopython=True)\n",
-    "def G(x, mu):\n",
-    "    return mu * x + 2 * (1 - mu) * x**2 / (1.0 + x**2)\n",
-    "\n",
-    "class Gumowski_Mira(Attractor):\n",
-    "    equations = param.List([r'$G(x) = \\mu x + \\frac{2(1-\\mu)x^2}{1+x^2}$',\n",
-    "                            r'$x_{n+1} = y_n + ay_n(1-by_n^2) + G(x_n)$', \n",
-    "                            r'$y_{n+1} = -x_n + G(x_{n+1})$'])\n",
-    "    \n",
-    "    x = param.Number(0,    softbounds=(-20, 20), doc=\"Starting x value\", precedence=0.1)\n",
-    "    y = param.Number(0,    softbounds=(-20, 20), doc=\"Starting y value\", precedence=0.1)\n",
-    "    a = param.Number(0.64, softbounds=( -1,  1))\n",
-    "    b = param.Number(0.76, softbounds=( -1,  1))\n",
-    "    mu = param.Number(0.6, softbounds=( -2,  2), doc=\"Attractor parameter mu\")\n",
-    "    \n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, mu, *o):\n",
-    "        xn = y + a*(1 - b*y**2)*y  +  G(x, mu)\n",
-    "        yn = -x + G(xn, mu)\n",
-    "        return xn, yn\n",
-    "\n",
-    "\n",
-    "class Symmetric_Icon(Attractor):\n",
-    "    a = param.Number(0.6, softbounds=(-20, 20),  bounds=(None,None), doc=\"Attractor parameter alpha\")\n",
-    "    b = param.Number(1.2, softbounds=(-20, 20),  bounds=(None,None), doc=\"Attractor parameter beta\")\n",
-    "    g = param.Number(0.6, softbounds=(-1,   1),  bounds=(None,None), doc=\"Attractor parameter gamma\")\n",
-    "    om= param.Number(1.2, softbounds=(-0.2, 0.2),bounds=(None,None), doc=\"Attractor parameter omega\")\n",
-    "    l = param.Number(0.6, softbounds=(-3,   3),  bounds=(None,None), doc=\"Attractor parameter lambda\")\n",
-    "    d = param.Number(1.2, softbounds=( 1,  20),  bounds=(None,None), doc=\"Attractor parameter degree\")\n",
-    "\n",
-    "    @staticmethod\n",
-    "    @jit(nopython=True)\n",
-    "    def fn(x, y, a, b, g, om, l, d, *o):\n",
-    "        zzbar = x*x + y*y\n",
-    "        p = a*zzbar + l\n",
-    "        zreal, zimag = x, y\n",
-    "    \n",
-    "        for i in range(1, d-1):\n",
-    "            za, zb = zreal * x - zimag * y, zimag * x + zreal * y\n",
-    "            zreal, zimag = za, zb\n",
-    "    \n",
-    "        zn = x*zreal - y*zimag\n",
-    "        p += b*zn\n",
-    "    \n",
-    "        return p*x + g*zreal - om*y, \\\n",
-    "               p*y - g*zimag + om*x"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Using these attractor objects, we can look at the equations for them:"
+    "h = at.Hopalong1()\n",
+    "h"
    ]
   },
   {
@@ -267,14 +45,7 @@
     "from IPython.core.display import display, HTML, Latex\n",
     "display(HTML(\"<style>.container { width:100% !important; }</style>\"))\n",
     "\n",
-    "display(*[Latex(e) for e in Gumowski_Mira.equations])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "And we can run them for specified parameter values to calculate `n` (x,y) positions of the simulated particle through space:"
+    "display(*[Latex(e) for e in h.equations])"
    ]
   },
   {
@@ -283,7 +54,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trajectory(Hopalong1.fn, 0, 0, a=1, b=3, c=5, n=5)"
+    "import inspect\n",
+    "print(inspect.getsource(h.fn))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `trajectory` function to run this equation for specified parameter values to calculate `n` (x,y) positions of the simulated particle through space, where each subsequent position is calculated from the previous one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "at.trajectory(h.fn, 0, 0, a=1, b=3, c=5, n=5)"
    ]
   },
   {
@@ -301,61 +89,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy.random as npr, yaml\n",
-    "npr.seed(12)\n",
-    "\n",
-    "class ParameterSets(param.Parameterized):\n",
-    "    \"\"\"\n",
-    "    Allows selection from sets of pre-defined parameters saved in YAML.\n",
-    "    \n",
-    "    Assumes the YAML file returns a list of groups of values.\n",
-    "    \"\"\"\n",
-    "\n",
-    "    examples_filename = param.Filename(\"attractors.yml\")\n",
-    "    remember_this_one = param.Action(lambda x: x._remember())\n",
-    "    \n",
-    "    load      = param.Action(lambda x: x._load())\n",
-    "    randomize = param.Action(lambda x: x._randomize())\n",
-    "    sort      = param.Action(lambda x: x._sort())\n",
-    "    save      = param.Action(lambda x: x._save(), precedence=0.8)\n",
-    "    example   = param.Selector(objects=[[]], precedence=-1)\n",
-    "\n",
-    "    def __init__(self,**params):\n",
-    "        super(ParameterSets,self).__init__(**params)\n",
-    "        self._load()\n",
-    "\n",
-    "    def _load(self):\n",
-    "        with open(self.examples_filename,\"r\") as f: \n",
-    "            vals = yaml.safe_load(f)\n",
-    "            assert(vals and len(vals)>0)\n",
-    "            self.param.example.objects=vals\n",
-    "            self.example = vals[0]\n",
-    "\n",
-    "    def _save(self):\n",
-    "        with open(self.examples_filename,\"w\") as f: \n",
-    "            yaml.dump(self.param.example.objects,f)\n",
-    "\n",
-    "    def __call__(self):        return self.example\n",
-    "    def _randomize(self):      npr.shuffle(self.param.example.objects)\n",
-    "    def _sort(self):           self.param.example.objects = list(sorted(self.param.example.objects))\n",
-    "    def _add_item(self, item): self.param.example.objects += [item] ; self.example=item\n",
-    "    def _remember(self):\n",
-    "        vals = ats.attractor_type.vals() # forward reference\n",
-    "        self._add_item(vals)\n",
-    "        \n",
-    "    def args(self, name):\n",
-    "        return [v[1:] for v in self.param.example.objects if v[0]==name]\n",
-    "\n",
-    "\n",
-    "params = ParameterSets(name=\"Attractors\")\n",
-    "#pn.Row(params)"
+    "params = at.ParameterSets(name=\"Attractors\")\n",
+    "params.attractors[\"Svensson\"]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now define an example of each attractor family and allow users to select between them or create a new one of a given type:"
+    "The `params` object also allows constructing a new Attractor object by name with the given parameters:"
    ]
   },
   {
@@ -364,30 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from param import concrete_descendents\n",
-    "from collections import OrderedDict\n",
-    "attractors = OrderedDict(sorted([(k,v(name=k + \" parameters\")) for k,v in concrete_descendents(Attractor).items()]))\n",
-    "\n",
-    "def attractor_obj(name, *args):\n",
-    "    \"\"\"Factory function to return an Attractor object with the given name and arg values\"\"\"\n",
-    "    attractor = attractors[name]\n",
-    "    fn_params = ['colormap'] + attractor.sig()\n",
-    "    attractor.param.set_param(**dict(zip(fn_params, args)))\n",
-    "    return attractor\n",
-    "\n",
-    "#attractor_obj('Gumowski_Mira', None, 0.1, 0.1, 0.0, 0.5, -0.75)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for k in attractors:\n",
-    "    attractor_obj(k, *params.args(k)[0])\n",
-    "\n",
-    "#pn.Row(attractors[\"Clifford\"], attractors[\"Svensson\"])"
+    "params.attractor('Gumowski_Mira', None, 0.1, 0.1, 0.0, 0.5, -0.75)"
    ]
   },
   {
@@ -414,12 +133,12 @@
     "\n",
     "size=700\n",
     "\n",
-    "def datashade(df, plot_type='points', cmap=palette[\"inferno\"]):\n",
+    "def datashade(df, plot_type='points', cmap=palette[\"inferno\"], size=size):\n",
     "    cvs = ds.Canvas(plot_width=size, plot_height=size)\n",
     "    agg = getattr(cvs,plot_type)(df, 'x', 'y', agg=ds.count())\n",
     "    return tf.shade(agg, cmap=cmap)\n",
     "\n",
-    "#datashade(trajectory(Hopalong1.fn, 0, 0, a=1, b=3, c=5, n=5000000))"
+    "datashade(at.trajectory(at.Hopalong1.fn, 0, 0, a=1, b=3, c=5, n=5000000), cmap=viridis, size=200)"
    ]
   },
   {
@@ -428,7 +147,7 @@
    "source": [
     "# Panel dashboard\n",
     "\n",
-    "We could use `datashade` on its own to plot any of these attractors, or `IPython.display.Latex` to render the equations mathematically. But to make it much simple to explore, let's build an app with widgets using Panel. We'll first make an object that lets us select between attractor families, types of plots, etc.:"
+    "As illustrated above, we can use `datashade` on its own to plot any of these attractors, or `IPython.display.Latex` to render the equations mathematically. But to make it much simpler to explore, let's build an app with widgets using Panel. We'll first make an object that lets us select between attractor families, types of plots, etc.:"
    ]
   },
   {
@@ -437,12 +156,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from panel import Column\n",
+    "import param, panel as pn\n",
     "from panel.pane import LaTeX\n",
+    "pn.extension('katex')\n",
     "\n",
     "class Attractors(param.Parameterized):\n",
-    "    attractor_type = param.ObjectSelector(attractors[\"Clifford\"], attractors,\n",
-    "                                          precedence=0.9)\n",
+    "    attractor_type = param.ObjectSelector(params.attractors[\"Clifford\"], \n",
+    "                                          params.attractors, precedence=0.9)\n",
     "\n",
     "    parameters = param.ObjectSelector(params, precedence=-0.5, readonly=True)\n",
     "\n",
@@ -454,7 +174,7 @@
     "    \n",
     "    @param.depends(\"parameters.param\", watch=True)\n",
     "    def _update_from_parameters(self):\n",
-    "        a = attractor_obj(*self.parameters())\n",
+    "        a = params.attractor(*self.parameters())\n",
     "        if a is not self.attractor_type:\n",
     "            self.set_param(attractor_type=a)\n",
     "        \n",
@@ -466,12 +186,12 @@
     "    @param.depends(\"attractor_type\")\n",
     "    def equations(self):\n",
     "        if not self.attractor_type.equations:\n",
-    "            return Column()\n",
-    "        return Column(\"<b>\"+self.attractor_type.__class__.name+\" attractor<b>\", \n",
+    "            return pn.Column()\n",
+    "        return pn.Column(\"<b>\"+self.attractor_type.__class__.name+\" attractor<b>\", \n",
     "                      *[LaTeX(e) for e in self.attractor_type.equations])\n",
     "\n",
     "ats = Attractors(name=\"Options\")\n",
-    "#ats.view()"
+    "#ats.view() # Uncomment to see a plot of the current attractor"
    ]
   },
   {
@@ -542,14 +262,14 @@
     "       pn.Column(text, pn.panel(ats.equations,margin=(0,-500,0,0))), pn.Spacer(max_width=20),\n",
     "       pn.Column(ats.view, player), pn.Spacer(max_width=20),\n",
     "       pn.Column(pn.Param(ats.param, expand=True, width=220)),\n",
-    "       HSpacer()).servable()"
+    "       HSpacer()).servable(\"Attractors\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can replace `.servable()` with `.show()` if you want to launch a standalone dashboard immediately from within the Jupyter notebook, or just run this notebook through Bokeh Server using `panel serve --show attractors_panel.ipynb`. Either way, you should get a browser tab with a dashboard like in the above cell, which you can explore or share."
+    "You can add `.show()` after `.servable()` if you want to launch a standalone dashboard immediately from within the Jupyter notebook, or just run this notebook through Bokeh Server using `panel serve --show attractors_panel.ipynb`. Either way, you should get a browser tab with a dashboard like in the above cell, which you can explore or share."
    ]
   }
  ],

--- a/attractors/attractors_panel.ipynb
+++ b/attractors/attractors_panel.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "To make the parameter spaces easy to explore, we'll build a web-based application using [Panel](https://panel.holoviz.org) to select between the attractor families, adjust the parameter values for that type of attractor, and see the results rendered using [Datashader](https://datashader.org). Using this app requires `conda install -c pyviz panel datashader` and a live, running Python process, not just a static web page or anaconda.org viewer. \n",
     "\n",
-    "This dashboard code also functions as an example of how to build a Panel application for working with an arbitrarily large family of Python objects organized into a class hierarchy, without depending on the details of that structure and without that code depending on any GUI libraries. In this approach, each object defines its own parameters in a GUI-independent way, but then Panel can access this information and construct appropriate widgets to provide interactive control of the values. This approach can allow the same codebase be used in a GUI with full interactivity while also supporting non-GUI command-line, batch, or headless usage. \n",
+    "This dashboard code also functions as an example of how to build a Panel application for working with an arbitrarily large family of Python objects organized into a class hierarchy, without depending on the details of that structure and without that code depending on any GUI libraries. In this approach, each object defines its own parameters in a GUI-independent way, but then Panel can access this information and construct appropriate widgets to provide interactive control of the values. This approach can allow the same codebase be used in a GUI with full interactivity while also supporting non-GUI command-line, batch, or headless usage. New classes added to the .py file, even with entirely different parameters, will automatically be supported by this GUI code.\n",
     "\n",
     "If you aren't familiar with Panel, you may wish to check out the much simpler [Clifford-only app](clifford_panel.ipynb) first, to understand the basic structure of an app and of how to compute an attractor.\n",
     "\n",
@@ -191,6 +191,7 @@
     "                      *[LaTeX(e) for e in self.attractor_type.equations])\n",
     "\n",
     "ats = Attractors(name=\"Options\")\n",
+    "params.current = lambda: ats.attractor_type\n",
     "#ats.view() # Uncomment to see a plot of the current attractor"
    ]
   },


### PR DESCRIPTION
Helps make it clear that the main domain-specific code (now in attractors.py) does not need to include any GUI code, and the GUI code (what's left in attractors_panel.ipynb) does not need to know the details of what's in attractors.py (i.e. will happily allow using and editing new classes added to attractors.py with no changes to the GUI code).