### PR TITLE
Added symlinks for shortened project URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,8 +263,8 @@ jobs:
         - git checkout -b deploy-${TRAVIS_BRANCH}
         - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated # all evaluated notebooks, json, and rst should be checked in to this branch
         - git checkout evaluated -- ./doc
-      script: doit build_website
-      after_script:
+      script:
+        - doit build_website
         - doit index_symlinks
       deploy:
         - provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -264,6 +264,8 @@ jobs:
         - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated # all evaluated notebooks, json, and rst should be checked in to this branch
         - git checkout evaluated -- ./doc
       script: doit build_website
+      after_script:
+        - doit index_symlinks
       deploy:
         - provider: pages
           skip_cleanup: true

--- a/dodo.py
+++ b/dodo.py
@@ -283,10 +283,10 @@ def task_index_symlinks():
 
     def generate_index_symlinks():
         for name in all_project_names(''):
-            project_path = os.path.join('doc', name)
+            project_path = os.path.join('builtdocs', name)
             print(name)
             print(project_path)
-            print(os.listdir('builtdocs', name))
+            print(os.listdir(project_path))
 
 
     return {'actions':[generate_index_symlinks]}

--- a/dodo.py
+++ b/dodo.py
@@ -291,8 +291,8 @@ def task_index_symlinks():
                 if 'index.html' not in listing:
                     os.symlink('./%s.html', './index.html')
                 print('Created symlink for %s' % name)
-            except:
-                pass
+            except Exception as e:
+                print(str(e))
         os.chdir(cwd)
     return {'actions':[generate_index_symlinks]}
 

--- a/dodo.py
+++ b/dodo.py
@@ -285,8 +285,15 @@ def task_index_symlinks():
         for name in all_project_names(''):
             project_path = os.path.join('..', 'builtdocs', name)
             print(name)
-            try: print(project_path)
+            try: print(">", project_path)
             except: pass
+
+            try: print(os.listdir('.'))
+            except: pass
+
+            try: print(os.listdir('..'))
+            except: pass
+
             try: print(os.listdir(os.path.join('..', 'builtdocs')))
             except: pass
             try: print(os.listdir(os.path.join('..', 'builtdocs', 'build')))

--- a/dodo.py
+++ b/dodo.py
@@ -286,7 +286,7 @@ def task_index_symlinks():
             project_path = os.path.join('doc', name)
             print(name)
             print(project_path)
-            print(os.listdir(project_path))
+            print(os.listdir(name))
 
 
     return {'actions':[generate_index_symlinks]}

--- a/dodo.py
+++ b/dodo.py
@@ -286,7 +286,7 @@ def task_index_symlinks():
             project_path = os.path.join('doc', name)
             print(name)
             print(project_path)
-            print(os.listdir(name))
+            print(os.listdir('builtdocs', name))
 
 
     return {'actions':[generate_index_symlinks]}

--- a/dodo.py
+++ b/dodo.py
@@ -284,10 +284,13 @@ def task_index_symlinks():
     def generate_index_symlinks():
         for name in all_project_names(''):
             project_path = os.path.join('.', 'builtdocs', name)
-            listing = os.listdir(project_path)
-            print(listing)
-            print('INDEX>', 'index.html' in listing)
-            print('PROJECT HTML>', ('%s.html' % name) in listing)
+            try:
+                listing = os.listdir(project_path)
+                print(listing)
+                print('INDEX>', 'index.html' in listing)
+                print('PROJECT HTML>', ('%s.html' % name) in listing)
+            except:
+                pass
 
     return {'actions':[generate_index_symlinks]}
 

--- a/dodo.py
+++ b/dodo.py
@@ -282,16 +282,18 @@ def task_index_symlinks():
     "Create relative symlinks to provide short, convenient project URLS"
 
     def generate_index_symlinks():
+        cwd = os.getcwd()
         for name in all_project_names(''):
-            project_path = os.path.join('.', 'builtdocs', name)
+            project_path = os.path.abspath(os.path.join('.', 'builtdocs', name))
             try:
+                os.chdir(project_path)
                 listing = os.listdir(project_path)
-                print(listing)
-                print('INDEX>', 'index.html' in listing)
-                print('PROJECT HTML>', ('%s.html' % name) in listing)
+                if 'index.html' not in listing:
+                    os.symlink('./%s.html', './index.html')
+                print('Created symlink for %s' % name)
             except:
                 pass
-
+        os.chdir(cwd)
     return {'actions':[generate_index_symlinks]}
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -288,19 +288,16 @@ def task_index_symlinks():
             try: print(">", project_path)
             except: pass
 
-            try: print(os.listdir('.'))
+            try: print('.', os.listdir('.'))
             except: pass
 
-            try: print(os.listdir('..'))
+            try: print('..', os.listdir('..'))
             except: pass
 
-            try: print(os.listdir(os.path.join('.', 'builtdocs')))
+            try: print("./builtdocs/>", os.listdir(os.path.join('.', 'builtdocs')))
             except: pass
-            try: print(os.listdir(os.path.join('.', 'builtdocs', 'build')))
+            try: print("./builtdocs/name>", os.listdir(os.path.join('.', 'builtdocs', name)))
             except: pass
-            try: print(os.listdir(os.path.join('.', 'builtdocs', 'build', 'html')))
-            except: pass
-
 
     return {'actions':[generate_index_symlinks]}
 

--- a/dodo.py
+++ b/dodo.py
@@ -283,21 +283,11 @@ def task_index_symlinks():
 
     def generate_index_symlinks():
         for name in all_project_names(''):
-            project_path = os.path.join('..', 'builtdocs', name)
-            print(name)
-            try: print(">", project_path)
-            except: pass
-
-            try: print('.', os.listdir('.'))
-            except: pass
-
-            try: print('..', os.listdir('..'))
-            except: pass
-
-            try: print("./builtdocs/>", os.listdir(os.path.join('.', 'builtdocs')))
-            except: pass
-            try: print("./builtdocs/name>", os.listdir(os.path.join('.', 'builtdocs', name)))
-            except: pass
+            project_path = os.path.join('.', 'builtdocs', name)
+            listing = os.listdir(project_path)
+            print(listing)
+            print('INDEX>', 'index.html' in listing)
+            print('PROJECT HTML>', ('%s.html' % name) in listing)
 
     return {'actions':[generate_index_symlinks]}
 

--- a/dodo.py
+++ b/dodo.py
@@ -287,6 +287,9 @@ def task_index_symlinks():
             print(name)
             print(project_path)
             print(os.listdir(project_path))
+            print(os.listdir(os.path.join('..', 'builtdocs')))
+            print(os.listdir(os.path.join('..', 'builtdocs', 'build')))
+            print(os.listdir(os.path.join('..', 'builtdocs', 'build', 'html')))
 
 
     return {'actions':[generate_index_symlinks]}

--- a/dodo.py
+++ b/dodo.py
@@ -294,11 +294,11 @@ def task_index_symlinks():
             try: print(os.listdir('..'))
             except: pass
 
-            try: print(os.listdir(os.path.join('..', 'builtdocs')))
+            try: print(os.listdir(os.path.join('.', 'builtdocs')))
             except: pass
-            try: print(os.listdir(os.path.join('..', 'builtdocs', 'build')))
+            try: print(os.listdir(os.path.join('.', 'builtdocs', 'build')))
             except: pass
-            try: print(os.listdir(os.path.join('..', 'builtdocs', 'build', 'html')))
+            try: print(os.listdir(os.path.join('.', 'builtdocs', 'build', 'html')))
             except: pass
 
 

--- a/dodo.py
+++ b/dodo.py
@@ -285,11 +285,14 @@ def task_index_symlinks():
         for name in all_project_names(''):
             project_path = os.path.join('..', 'builtdocs', name)
             print(name)
-            print(project_path)
-            print(os.listdir(project_path))
-            print(os.listdir(os.path.join('..', 'builtdocs')))
-            print(os.listdir(os.path.join('..', 'builtdocs', 'build')))
-            print(os.listdir(os.path.join('..', 'builtdocs', 'build', 'html')))
+            try: print(project_path)
+            except: pass
+            try: print(os.listdir(os.path.join('..', 'builtdocs')))
+            except: pass
+            try: print(os.listdir(os.path.join('..', 'builtdocs', 'build')))
+            except: pass
+            try: print(os.listdir(os.path.join('..', 'builtdocs', 'build', 'html')))
+            except: pass
 
 
     return {'actions':[generate_index_symlinks]}

--- a/dodo.py
+++ b/dodo.py
@@ -289,7 +289,7 @@ def task_index_symlinks():
                 os.chdir(project_path)
                 listing = os.listdir(project_path)
                 if 'index.html' not in listing:
-                    os.symlink('./%s.html', './index.html')
+                    os.symlink('./%s.html' % name, './index.html')
                 print('Created symlink for %s' % name)
                 os.chdir(cwd)
             except Exception as e:

--- a/dodo.py
+++ b/dodo.py
@@ -291,6 +291,7 @@ def task_index_symlinks():
                 if 'index.html' not in listing:
                     os.symlink('./%s.html', './index.html')
                 print('Created symlink for %s' % name)
+                os.chdir(cwd)
             except Exception as e:
                 print(str(e))
         os.chdir(cwd)

--- a/dodo.py
+++ b/dodo.py
@@ -283,7 +283,7 @@ def task_index_symlinks():
 
     def generate_index_symlinks():
         for name in all_project_names(''):
-            project_path = os.path.join('builtdocs', name)
+            project_path = os.path.join('..', 'builtdocs', name)
             print(name)
             print(project_path)
             print(os.listdir(project_path))

--- a/dodo.py
+++ b/dodo.py
@@ -278,6 +278,20 @@ def task_build_website():
         "nbsite build --examples .",
     ]}
 
+def task_index_symlinks():
+    "Create relative symlinks to provide short, convenient project URLS"
+
+    def generate_index_symlinks():
+        for name in all_project_names(''):
+            project_path = os.path.join('doc', name)
+            print(name)
+            print(project_path)
+            print(os.listdir(project_path))
+
+
+    return {'actions':[generate_index_symlinks]}
+
+
 def task_changes_in_dir():
     def changes_in_dir(name, filepath='.diff'):
         if not dir_is_project(name):


### PR DESCRIPTION
Links to `$PROJECT.html` as an `index.html` symlink when an `index.html` doesn't exist already.