### PR TITLE
add commit message and tag build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ stages:
   - name: build_project
     if: commit_message =~ /^.*(build:).*$/
   - name: website_dev
-    if: (commit_message =~ /^.*(build:).*$/) OR (branch = master)
+    if: (tag =~ ^v(\d+|\.)+[a-z]\d+$) OR (tag = website_dev) OR (commit_message =~ /^.*(website_dev).*$/)
   - name: website_release
-    if: (commit_message =~ /^.*(build:).*$/) AND (commit_message =~ /^.*(website_release).*$/)
+    if: (tag =~ ^v(\d+|\.)+[^a-z]\d+$) OR (tag = website) OR (commit_message =~ /^.*(website_release).*$/)
 
 jobs:
   include:


### PR DESCRIPTION
This adds support for building dev and release websites with commit messages containing `website_dev` and `website_release` respectively, and building building from tags using `website_release` and `website_dev`, as well as tags of the format `v1.3.1a4` for dev, and `v1.3.1A4` for release.