### PR TITLE
Fixing symlink creation on GH Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,7 @@ jobs:
           conda activate test-environment
           doit build_website
           doit index_symlinks
+          sudo chown -R $(id -u):$(id -g) ./builtdocs   
       - name: Deploy dev
         uses: crazy-max/ghaction-github-pages@v2
         if: "!contains(github.event.head_commit.message, 'website_release')"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
           eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit build_website
-          doit index_symlinks
+          doit index_redirects
           sudo chown -R $(id -u):$(id -g) ./builtdocs   
       - name: Deploy dev
         uses: crazy-max/ghaction-github-pages@v2

--- a/dodo.py
+++ b/dodo.py
@@ -290,7 +290,8 @@ def task_index_symlinks():
                 listing = os.listdir(project_path)
                 if 'index.html' not in listing:
                     os.symlink('./%s.html' % name, './index.html')
-                print('Created symlink for %s' % name)
+                    print('Created symlink for %s' % name)
+                    print(os.listdir('.'))
                 os.chdir(cwd)
             except Exception as e:
                 print(str(e))

--- a/dodo.py
+++ b/dodo.py
@@ -289,9 +289,8 @@ def task_index_symlinks():
                 os.chdir(project_path)
                 listing = os.listdir(project_path)
                 if 'index.html' not in listing:
-                    os.system('ln -s %s.html index.html' % name)
+                    os.symlink('./%s.html' % name, './index.html')
                     print('Created symlink for %s' % name)
-                    print(os.listdir('.'))
                 os.chdir(cwd)
             except Exception as e:
                 print(str(e))

--- a/dodo.py
+++ b/dodo.py
@@ -289,7 +289,7 @@ def task_index_symlinks():
                 os.chdir(project_path)
                 listing = os.listdir(project_path)
                 if 'index.html' not in listing:
-                    os.symlink('./%s.html' % name, './index.html')
+                    os.system('ln -s %s.html index.html' % name)
                     print('Created symlink for %s' % name)
                     print(os.listdir('.'))
                 os.chdir(cwd)

--- a/dodo.py
+++ b/dodo.py
@@ -298,6 +298,46 @@ def task_index_symlinks():
     return {'actions':[generate_index_symlinks]}
 
 
+redirect_template = """
+<!DOCTYPE html>
+<html>
+   <head>
+      <title>{name} redirect</title>
+      <meta http-equiv = "refresh" content = "0; url = https://examples.pyviz.org/{name}/{name}.html" />
+   </head>
+</html>
+"""
+
+
+def task_index_redirects():
+    """
+    Create redirect pages to provide short, convenient project URLS.
+    Should behave the same as task_index_symlinks but can be used where
+    symlinks are not suitable.
+
+    """
+    def write_redirect(name):
+        with open('./index.html', 'w') as f:
+            contents = redirect_template.format(name=name)
+            f.write(contents)
+            print('Created relative HTML redirect for %s' % name)
+
+    def generate_index_redirect():
+        cwd = os.getcwd()
+        for name in all_project_names(''):
+            project_path = os.path.abspath(os.path.join('.', 'builtdocs', name))
+            try:
+                os.chdir(project_path)
+                listing = os.listdir(project_path)
+                if 'index.html' not in listing:
+                    write_redirect(name)
+                os.chdir(cwd)
+            except Exception as e:
+                print(str(e))
+        os.chdir(cwd)
+    return {'actions':[generate_index_redirect]}
+
+
 def task_changes_in_dir():
     def changes_in_dir(name, filepath='.diff'):
         if not dir_is_project(name):


### PR DESCRIPTION
The symlinks are necessary to allow the shortened URLs on examples.pyviz. Creation was working on Travis but no longer seems to be working on GH Actions. The public website can be fixed by manually pushing the symlinks to `gh-pages` but that is easily forgotten and not a long term solution.