### PR TITLE
Re-enable doit small_data_cleanup step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
               if doit changes_in_dir --name $DIR; then
                 doit small_data_setup --name $DIR
                 doit test_project --name $DIR
-                # doit small_data_cleanup --name $DIR
+                doit small_data_cleanup --name $DIR
               fi;
             fi;
           done


### PR DESCRIPTION
This step was commented out to get the `ship_traffic` project built. Presumably it did something important and useful so this PR is here to re-enable it.