### PR TITLE
Updated dependencies for bay_trimesh

### DIFF
--- a/bay_trimesh/anaconda-project-lock.yml
+++ b/bay_trimesh/anaconda-project-lock.yml
@@ -8,8 +8,9 @@
 
 #
 # Set to false to ignore locked versions.
-#
 locking_enabled: true
+
+
 
 #
 # A key goes in here for each env spec.
@@ -17,842 +18,938 @@ locking_enabled: true
 env_specs:
   test:
     locked: true
-    env_spec_hash: 3e568e1de852869ce63bb4d57212554a5d569889
+    env_spec_hash: 2e5bcfbb8d7ef66c837b19af69c1e83f3b36e510
     platforms:
     - linux-64
     - osx-64
     - win-64
     packages:
       all:
+      - async_generator=1.10=py36h28b3542_0
       - atomicwrites=1.4.0=py_0
-      - attrs=19.3.0=py_0
-      - backcall=0.1.0=py36_0
-      - beautifulsoup4=4.9.0=py36_0
+      - attrs=21.2.0=pyhd3eb1b0_0
+      - backcall=0.2.0=pyhd3eb1b0_0
+      - beautifulsoup4=4.9.3=pyha847dfd_0
       - blas=1.0=mkl
-      - bleach=3.1.4=py_0
-      - bokeh=2.0.2=py36_0
-      - ca-certificates=2020.1.1=0
-      - certifi=2020.4.5.1=py36_0
-      - chardet=3.0.4=py36_1003
+      - bleach=3.3.0=pyhd3eb1b0_0
+      - bokeh=1.4.0=py36_0
       - click-plugins=1.1.1=py_0
-      - click=7.1.2=py_0
-      - cligj=0.5.0=py36_0
-      - cloudpickle=1.4.1=py_0
+      - click=7.1.2=pyhd3eb1b0_0
+      - cloudpickle=1.6.0=py_0
       - colorcet=2.0.1=py_0
       - contextvars=2.4=py_0
-      - dask-core=2.17.0=py_0
-      - dask=2.17.0=py_0
-      - datashader=0.7.0=py_0
-      - datashape=0.5.4=py36_1
-      - decorator=4.4.2=py_0
-      - defusedxml=0.6.0=py_0
-      - distributed=2.17.0=py36_0
+      - dask-core=2.30.0=py_0
+      - dask=2.30.0=py_0
+      - datashader=0.12.1=pyhd3eb1b0_1
+      - decorator=5.0.7=pyhd3eb1b0_0
+      - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py36_0
-      - fsspec=0.7.1=py_0
-      - geopandas=0.6.1=py_0
-      - geoviews-core=1.6.2=py_0
-      - geoviews=1.6.2=py_0
+      - fsspec=0.9.0=pyhd3eb1b0_0
+      - geoviews-core=1.6.6=py_0
+      - geoviews=1.6.6=py_0
       - heapdict=1.0.1=py_0
-      - holoviews=1.12.3=py_2
-      - idna=2.9=py_1
-      - imageio=2.8.0=py_0
-      - importlib-metadata=1.6.0=py36_0
-      - importlib_metadata=1.6.0=0
+      - holoviews=1.12.7=py_0
+      - idna=2.10=pyhd3eb1b0_0
+      - importlib_metadata=3.10.0=hd3eb1b0_0
       - ipykernel=5.1.0=py36h39e3cac_0
-      - ipython=7.13.0=py36h5ca1d4c_0
-      - ipython_genutils=0.2.0=py36_0
-      - ipywidgets=7.5.1=py_0
+      - ipython=7.16.1=py36h5ca1d4c_0
+      - ipython_genutils=0.2.0=pyhd3eb1b0_1
+      - ipywidgets=7.6.3=pyhd3eb1b0_1
       - jedi=0.17.0=py36_0
-      - jinja2=2.11.2=py_0
-      - jsonschema=3.2.0=py36_0
+      - jinja2=3.0.0=pyhd3eb1b0_0
+      - jsonschema=3.2.0=py_2
       - jupyter=1.0.0=py36_7
-      - jupyter_client=6.1.3=py_0
-      - jupyter_console=6.1.0=py_0
-      - jupyter_core=4.6.3=py36_0
-      - matplotlib=3.1.3=py36_0
-      - more-itertools=8.3.0=py_0
+      - jupyter_client=6.1.12=pyhd3eb1b0_0
+      - jupyter_console=6.4.0=pyhd3eb1b0_0
+      - jupyterlab_pygments=0.1.2=py_0
+      - jupyterlab_widgets=1.0.0=pyhd3eb1b0_1
+      - more-itertools=8.7.0=pyhd3eb1b0_0
       - multipledispatch=0.6.0=py36_0
       - munch=2.5.0=py_0
-      - nbconvert=5.6.1=py36_0
-      - nbformat=5.0.6=py_0
+      - nbclient=0.5.3=pyhd3eb1b0_0
+      - nbconvert=6.0.7=py36_0
+      - nbformat=5.1.3=pyhd3eb1b0_0
       - nbsmoke=0.2.8=py36_0
-      - networkx=2.4=py_0
+      - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - notebook=5.7.8=py36_0
       - olefile=0.46=py36_0
-      - owslib=0.18.0=py_0
-      - packaging=20.3=py_0
-      - pandoc=2.2.3.2=0
-      - pandocfilters=1.4.2=py36_1
-      - param=1.9.3=py_0
-      - parso=0.7.0=py_0
-      - partd=1.1.0=py_0
-      - pickleshare=0.7.5=py36_0
-      - pip=20.0.2=py36_3
-      - pluggy=0.13.1=py36_0
-      - prometheus_client=0.7.1=py_0
-      - prompt-toolkit=3.0.4=py_0
-      - prompt_toolkit=3.0.4=0
-      - py=1.8.1=py_0
-      - pycparser=2.20=py_0
-      - pyct=0.4.6=py36_0
-      - pyepsg=0.4.0=py36_0
-      - pyflakes=2.2.0=py_0
-      - pygments=2.6.1=py_0
-      - pyopenssl=19.1.0=py36_0
-      - pyparsing=2.4.7=py_0
-      - pyshp=2.1.0=py_0
-      - pysocks=1.7.1=py36_0
+      - packaging=20.9=pyhd3eb1b0_0
+      - param=1.9.0=py_0
+      - parso=0.8.2=pyhd3eb1b0_0
+      - partd=1.2.0=pyhd3eb1b0_0
+      - pickleshare=0.7.5=pyhd3eb1b0_1003
+      - prometheus_client=0.10.1=pyhd3eb1b0_0
+      - prompt-toolkit=3.0.17=pyh06a4308_0
+      - prompt_toolkit=3.0.17=hd3eb1b0_0
+      - py=1.10.0=pyhd3eb1b0_0
+      - pycparser=2.20=py_2
+      - pyct=0.4.8=py36_0
+      - pyflakes=2.3.1=pyhd3eb1b0_0
+      - pygments=2.8.1=pyhd3eb1b0_0
+      - pyopenssl=20.0.1=pyhd3eb1b0_1
+      - pyparsing=2.4.7=pyhd3eb1b0_0
+      - pyshp=2.1.3=pyhd3eb1b0_0
       - pytest=4.4.1=py36_0
-      - python-dateutil=2.8.1=py_0
-      - pytz=2020.1=py_0
-      - pyviz_comms=0.7.4=py_0
-      - qtconsole=4.7.4=py_0
+      - python-dateutil=2.8.1=pyhd3eb1b0_0
+      - pytz=2021.1=pyhd3eb1b0_0
+      - pyviz_comms=2.0.1=pyhd3eb1b0_0
+      - qtconsole=5.0.3=pyhd3eb1b0_0
       - qtpy=1.9.0=py_0
-      - requests=2.23.0=py36_0
-      - send2trash=1.5.0=py36_0
-      - setuptools=46.4.0=py36_0
-      - six=1.14.0=py36_0
-      - sortedcontainers=2.1.0=py36_0
-      - soupsieve=2.0.1=py_0
-      - tblib=1.6.0=py_0
-      - terminado=0.8.3=py36_0
-      - testpath=0.4.4=py_0
-      - toolz=0.10.0=py_0
+      - requests=2.25.1=pyhd3eb1b0_0
+      - send2trash=1.5.0=pyhd3eb1b0_1
+      - sortedcontainers=2.3.0=pyhd3eb1b0_0
+      - soupsieve=2.2.1=pyhd3eb1b0_0
+      - tblib=1.7.0=py_0
+      - testpath=0.4.4=pyhd3eb1b0_0
+      - toolz=0.11.1=pyhd3eb1b0_0
       - traitlets=4.3.3=py36_0
-      - typing_extensions=3.7.4.1=py36_0
-      - urllib3=1.25.8=py36_0
-      - wcwidth=0.1.9=py_0
+      - typing_extensions=3.7.4.3=pyha847dfd_0
+      - urllib3=1.26.4=pyhd3eb1b0_0
+      - wcwidth=0.2.5=py_0
       - webencodings=0.5.1=py36_1
-      - wheel=0.34.2=py36_0
+      - wheel=0.36.2=pyhd3eb1b0_0
       - widgetsnbextension=3.5.1=py36_0
       - xarray=0.14.1=py_1
-      - zict=2.0.0=py_0
-      - zipp=3.1.0=py_0
+      - zict=2.0.0=pyhd3eb1b0_0
+      - zipp=3.4.1=pyhd3eb1b0_0
       unix:
-      - pexpect=4.8.0=py36_0
-      - poppler-data=0.4.9=0
-      - ptyprocess=0.6.0=py36_0
-      - rtree=0.9.4=py36_1
+      - geopandas=0.6.1=py_0
+      - owslib=0.18.0=py_0
+      - pexpect=4.8.0=pyhd3eb1b0_3
+      - ptyprocess=0.7.0=pyhd3eb1b0_2
+      - pyepsg=0.4.0=py36_0
       linux-64:
       - _libgcc_mutex=0.1=main
+      - brotlipy=0.7.0=py36h27cfd23_1003
       - bzip2=1.0.8=h7b6447c_0
+      - ca-certificates=2021.4.13=h06a4308_1
       - cairo=1.14.12=h8948797_3
       - cartopy=0.17.0=py36hbb7e04d_1
+      - certifi=2020.12.5=py36h06a4308_0
       - cffi=1.14.0=py36h2e261b9_0
-      - cftime=1.1.2=py36heb32a55_0
-      - cryptography=2.9.2=py36h1ba5d50_0
+      - cftime=1.4.1=py36h6323ea4_0
+      - chardet=4.0.0=py36h06a4308_1003
+      - cligj=0.7.1=py36h06a4308_0
+      - cryptography=3.4.7=py36hd23ed53_0
       - curl=7.67.0=hbc83047_0
       - cycler=0.10.0=py36_0
-      - cytoolz=0.10.1=py36h7b6447c_0
-      - dbus=1.13.14=hb2f20db_0
-      - expat=2.2.6=he6710b0_0
+      - cytoolz=0.11.0=py36h7b6447c_0
+      - datashape=0.5.4=py36h06a4308_1
+      - dbus=1.13.18=hb2f20db_0
+      - distributed=2.30.1=py36h06a4308_0
+      - expat=2.3.0=h2531618_2
       - fiona=1.8.4=py36hc38cc03_0
-      - fontconfig=2.13.0=h9420a91_0
-      - freetype=2.9.1=h8a8886c_1
-      - freexl=1.0.5=h14c3975_0
+      - fontconfig=2.13.1=h6c09931_0
+      - freetype=2.10.4=h5ab3b9f_0
+      - freexl=1.0.6=h27cfd23_0
       - gdal=2.3.3=py36hbb2a789_0
       - geos=3.7.1=he6710b0_0
       - giflib=5.1.4=h14c3975_1
       - glib=2.63.1=h5a9c865_0
-      - gmp=6.1.2=h6c8ec71_1
       - gst-plugins-base=1.14.0=hbbd80ab_1
       - gstreamer=1.14.0=hb453b48_1
       - hdf4=4.2.13=h3ca952b_2
       - hdf5=1.10.4=hb1b8bf9_0
       - icu=58.2=he6710b0_3
-      - immutables=0.11=py36h7b6447c_0
-      - intel-openmp=2020.1=217
+      - immutables=0.15=py36h27cfd23_0
+      - importlib-metadata=3.10.0=py36h06a4308_0
+      - intel-openmp=2021.2.0=h06a4308_610
       - jpeg=9b=h024ee3a_2
       - json-c=0.13.1=h1bed415_0
+      - jupyter_core=4.7.1=py36h06a4308_0
       - kealib=1.4.7=hd0c454d_6
-      - kiwisolver=1.2.0=py36hfd86e86_0
+      - kiwisolver=1.3.1=py36h2531618_0
       - krb5=1.16.4=h173b8e3_0
+      - lcms2=2.12=h3be6417_0
       - ld_impl_linux-64=2.33.1=h53a641e_7
       - libboost=1.67.0=h46d08c1_4
       - libcurl=7.67.0=h20c2e04_0
       - libdap4=3.19.1=h6ec2957_0
-      - libedit=3.1.20181209=hc058e9b_0
-      - libffi=3.2.1=hd88cf55_4
+      - libedit=3.1.20210216=h27cfd23_1
+      - libffi=3.2.1=hf484d3e_1007
       - libgcc-ng=9.1.0=hdf63c60_0
       - libgdal=2.3.3=h2e7e64b_0
       - libgfortran-ng=7.3.0=hdf63c60_0
       - libkml=1.3.0=h590aaf7_4
+      - libllvm10=10.0.1=hbcb73fb_5
       - libnetcdf=4.6.1=h11d0813_2
       - libpng=1.6.37=hbc83047_0
       - libpq=11.2=h20c2e04_0
-      - libsodium=1.0.16=h1bed415_0
-      - libspatialindex=1.9.3=he6710b0_0
+      - libsodium=1.0.18=h7b6447c_0
+      - libspatialindex=1.9.3=h2531618_0
       - libspatialite=4.3.0a=hb08deb6_19
       - libssh2=1.9.0=h1ba5d50_1
       - libstdcxx-ng=9.1.0=hdf63c60_0
-      - libtiff=4.1.0=h2733197_0
+      - libtiff=4.1.0=h2733197_1
       - libuuid=1.0.3=h1bed415_2
-      - libxcb=1.13=h1bed415_1
-      - libxml2=2.9.9=hea5a465_1
-      - libxslt=1.1.33=h7d1a2b0_0
-      - llvmlite=0.32.1=py36hd408876_0
-      - locket=0.2.0=py36_1
-      - lxml=4.5.0=py36hefd8a0e_0
-      - markupsafe=1.1.1=py36h7b6447c_0
-      - matplotlib-base=3.1.3=py36hef1b27d_0
+      - libxcb=1.14=h7b6447c_0
+      - libxml2=2.9.10=hb55368b_3
+      - libxslt=1.1.34=hc22bd24_0
+      - llvmlite=0.36.0=py36h612dafd_4
+      - locket=0.2.1=py36h06a4308_1
+      - lxml=4.6.3=py36h9120a33_0
+      - lz4-c=1.9.3=h2531618_0
+      - markupsafe=2.0.0=py36h27cfd23_0
+      - matplotlib-base=3.3.4=py36h62a2d02_0
+      - matplotlib=3.3.4=py36h06a4308_0
       - mistune=0.8.4=py36h7b6447c_0
-      - mkl-service=2.3.0=py36he904b0f_0
-      - mkl=2020.1=217
-      - mkl_fft=1.0.15=py36ha843d7b_0
+      - mkl-service=2.3.0=py36he8ac12f_0
+      - mkl=2020.2=256
+      - mkl_fft=1.3.0=py36h54f3939_0
       - mkl_random=1.1.1=py36h0573a6f_0
-      - msgpack-python=1.0.0=py36hfd86e86_1
+      - msgpack-python=1.0.2=py36hff7bd54_1
       - ncurses=6.2=he6710b0_1
       - netcdf4=1.4.2=py36h808af73_0
-      - numba=0.49.1=py36h0573a6f_0
-      - numpy-base=1.18.1=py36hde5b4d6_1
-      - numpy=1.18.1=py36h4f9e942_0
+      - numba=0.53.1=py36ha9443f7_0
+      - numpy-base=1.19.2=py36hfa32c7d_0
+      - numpy=1.19.2=py36h54aff64_0
       - openjpeg=2.3.0=h05c96fa_1
-      - openssl=1.1.1g=h7b6447c_0
+      - openssl=1.1.1k=h27cfd23_0
       - pandas=0.24.2=py36he6710b0_0
-      - pcre=8.43=he6710b0_0
-      - pillow=7.1.2=py36hb39fc2d_0
-      - pixman=0.38.0=h7b6447c_0
+      - pandoc=2.12=h06a4308_0
+      - pandocfilters=1.4.3=py36h06a4308_1
+      - pcre=8.44=he6710b0_0
+      - pillow=8.2.0=py36he98fc37_0
+      - pip=21.0.1=py36h06a4308_0
+      - pixman=0.40.0=h7b6447c_0
+      - pluggy=0.13.1=py36h06a4308_0
+      - poppler-data=0.4.10=h06a4308_0
       - poppler=0.65.0=h581218d_1
       - proj4=5.2.0=he6710b0_1
-      - psutil=5.7.0=py36h7b6447c_0
-      - pykdtree=1.3.1=py36hdd07704_2
+      - psutil=5.8.0=py36h27cfd23_1
+      - pykdtree=1.3.4=py36h6323ea4_1002
       - pyproj=1.9.6=py36h14380d9_0
       - pyqt=5.9.2=py36h05f1152_2
-      - pyrsistent=0.16.0=py36h7b6447c_0
+      - pyrsistent=0.17.3=py36h7b6447c_0
+      - pysocks=1.7.1=py36h06a4308_0
       - python=3.6.10=h191fe78_1
-      - pywavelets=1.1.1=py36h7b6447c_0
-      - pyyaml=5.3.1=py36h7b6447c_0
-      - pyzmq=18.1.1=py36he6710b0_0
+      - pyyaml=5.4.1=py36h27cfd23_1
+      - pyzmq=20.0.0=py36h2531618_1
       - qt=5.9.7=h5867ecd_1
       - readline=7.0=h7b6447c_5
-      - scikit-image=0.16.2=py36h0573a6f_0
-      - scipy=1.4.1=py36h0b6359f_0
+      - rtree=0.9.7=py36h06a4308_1
+      - scipy=1.5.2=py36h0b6359f_0
+      - setuptools=52.0.0=py36h06a4308_0
       - shapely=1.6.4=py36h86c5351_0
       - sip=4.19.8=py36hf484d3e_0
-      - sqlite=3.31.1=h62c20be_1
-      - tbb=2020.0=hfd86e86_0
-      - tk=8.6.8=hbc83047_0
-      - tornado=6.0.4=py36h7b6447c_1
-      - xerces-c=3.2.2=h780794e_0
+      - six=1.15.0=py36h06a4308_0
+      - sqlite=3.33.0=h62c20be_0
+      - tbb=2020.3=hfd86e86_0
+      - terminado=0.9.4=py36h06a4308_0
+      - tk=8.6.10=hbc83047_0
+      - tornado=6.1=py36h27cfd23_0
+      - xerces-c=3.2.3=h780794e_0
       - xz=5.2.5=h7b6447c_0
-      - yaml=0.1.7=had09818_2
-      - zeromq=4.3.1=he6710b0_3
+      - yaml=0.2.5=h7b6447c_0
+      - zeromq=4.3.4=h2531618_0
       - zlib=1.2.11=h7b6447c_3
-      - zstd=1.3.7=h0b5b093_0
+      - zstd=1.4.9=haebb681_0
       osx-64:
-      - appnope=0.1.0=py36hf537a9a_0
+      - appnope=0.1.2=py36hecd8cb5_1001
+      - brotlipy=0.7.0=py36h9ed2024_1003
       - bzip2=1.0.8=h1de35cc_0
+      - ca-certificates=2021.4.13=hecd8cb5_1
       - cairo=1.14.12=hc4e6be7_4
       - cartopy=0.17.0=py36haea56ea_1
+      - certifi=2020.12.5=py36hecd8cb5_0
       - cffi=1.14.0=py36hb5b8e2f_0
-      - cftime=1.1.2=py36h776bbcc_0
-      - cryptography=2.9.2=py36ha12b0ac_0
+      - cftime=1.4.1=py36he3068b8_0
+      - chardet=4.0.0=py36hecd8cb5_1003
+      - cligj=0.7.1=py36hecd8cb5_0
+      - cryptography=3.4.7=py36h2fd3fbb_0
       - curl=7.67.0=ha441bb4_0
-      - cycler=0.10.0=py36hfc81398_0
-      - cytoolz=0.10.1=py36h1de35cc_0
-      - dbus=1.13.14=h517e14e_0
-      - expat=2.2.6=h0a44026_0
+      - cycler=0.10.0=py36hecd8cb5_0
+      - cytoolz=0.11.0=py36haf1e3a3_0
+      - datashape=0.5.4=py36hecd8cb5_1
+      - dbus=1.13.18=h18a8e69_0
+      - distributed=2.30.1=py36hecd8cb5_0
+      - expat=2.3.0=h23ab428_2
       - fiona=1.8.4=py36h9a122fd_0
-      - fontconfig=2.13.0=h5d5b041_1
-      - freetype=2.9.1=hb4e5f40_0
-      - freexl=1.0.5=h1de35cc_0
+      - fontconfig=2.13.1=ha9ee91d_0
+      - freetype=2.10.4=ha233b18_0
+      - freexl=1.0.6=h9ed2024_0
       - gdal=2.3.3=py36hbe65578_0
       - geos=3.7.1=h0a44026_0
-      - gettext=0.19.8.1=h15daf44_3
+      - gettext=0.21.0=h7535e17_0
       - giflib=5.1.4=h1de35cc_1
       - glib=2.63.1=hd977a24_0
       - hdf4=4.2.13=h39711bb_2
       - hdf5=1.10.4=hfa1e0ec_0
       - icu=58.2=h0a44026_3
-      - immutables=0.11=py36h1de35cc_0
-      - intel-openmp=2019.4=233
+      - immutables=0.15=py36h9ed2024_0
+      - importlib-metadata=3.10.0=py36hecd8cb5_0
+      - intel-openmp=2021.2.0=hecd8cb5_564
       - jpeg=9b=he5867d9_2
       - json-c=0.13.1=h3efe00b_0
+      - jupyter_core=4.7.1=py36hecd8cb5_0
       - kealib=1.4.7=hf5ed860_6
-      - kiwisolver=1.2.0=py36h04f5b5a_0
+      - kiwisolver=1.3.1=py36h23ab428_0
       - krb5=1.16.4=hddcf347_0
+      - lcms2=2.12=hf1fd2bf_0
       - libboost=1.67.0=hebc422b_4
       - libcurl=7.67.0=h051b688_0
       - libcxx=10.0.0=1
       - libdap4=3.19.1=h3d3e54a_0
-      - libedit=3.1.20181209=hb402a30_0
-      - libffi=3.2.1=h0a44026_6
+      - libedit=3.1.20210216=h9ed2024_1
+      - libffi=3.2.1=h0a44026_1007
       - libgdal=2.3.3=h0950a36_0
       - libgfortran=3.0.1=h93005f0_2
       - libiconv=1.16=h1de35cc_0
       - libkml=1.3.0=hbe12b63_4
+      - libllvm10=10.0.1=h76017ad_5
       - libnetcdf=4.6.1=hd5207e6_2
       - libpng=1.6.37=ha441bb4_0
       - libpq=11.2=h051b688_0
-      - libsodium=1.0.16=h3efe00b_0
-      - libspatialindex=1.9.3=h0a44026_0
+      - libsodium=1.0.18=h1de35cc_0
+      - libspatialindex=1.9.3=h23ab428_0
       - libspatialite=4.3.0a=h644ec7d_19
       - libssh2=1.9.0=ha12b0ac_1
-      - libtiff=4.1.0=hcb84e12_0
-      - libxml2=2.9.9=hf6e021a_1
-      - libxslt=1.1.33=h33a18ac_0
+      - libtiff=4.1.0=hcb84e12_1
+      - libxml2=2.9.10=h7cdb67c_3
+      - libxslt=1.1.34=h83b36ba_0
       - llvm-openmp=10.0.0=h28b9765_0
-      - llvmlite=0.32.1=py36h8c7ce04_0
-      - locket=0.2.0=py36hca03003_1
-      - lxml=4.5.0=py36hef8c89e_0
-      - markupsafe=1.1.1=py36h1de35cc_0
-      - matplotlib-base=3.1.3=py36h9aa3819_0
+      - llvmlite=0.36.0=py36he4411ff_4
+      - locket=0.2.1=py36hecd8cb5_1
+      - lxml=4.6.3=py36h26b266a_0
+      - lz4-c=1.9.3=h23ab428_0
+      - markupsafe=2.0.0=py36h9ed2024_0
+      - matplotlib-base=3.3.4=py36h8b3ea08_0
+      - matplotlib=3.3.4=py36hecd8cb5_0
       - mistune=0.8.4=py36h1de35cc_0
-      - mkl-service=2.3.0=py36hfbe908c_0
+      - mkl-service=2.3.0=py36h9ed2024_0
       - mkl=2019.4=233
-      - mkl_fft=1.0.15=py36h5e564d8_0
+      - mkl_fft=1.3.0=py36ha059aab_0
       - mkl_random=1.1.1=py36h959d312_0
-      - msgpack-python=1.0.0=py36h04f5b5a_1
+      - msgpack-python=1.0.2=py36hf7b0b51_1
       - ncurses=6.2=h0a44026_1
       - netcdf4=1.4.2=py36h13743db_0
-      - numba=0.49.1=py36h86efe34_0
-      - numpy-base=1.18.1=py36h3304bdc_1
-      - numpy=1.18.1=py36h7241aed_0
+      - numba=0.53.0=py36hb2f4e1b_0
+      - numpy-base=1.19.2=py36hcfb5961_0
+      - numpy=1.19.2=py36h456fd55_0
       - openjpeg=2.3.0=hb95cd4c_1
-      - openssl=1.1.1g=h1de35cc_0
+      - openssl=1.1.1k=h9ed2024_0
       - pandas=0.24.2=py36h0a44026_0
-      - pcre=8.43=h0a44026_0
-      - pillow=7.1.2=py36h4655f20_0
-      - pixman=0.38.0=h1de35cc_0
+      - pandoc=2.12=hecd8cb5_0
+      - pandocfilters=1.4.3=py36hecd8cb5_1
+      - pcre=8.44=hb1e8313_0
+      - pillow=8.2.0=py36h5270095_0
+      - pip=21.0.1=py36hecd8cb5_0
+      - pixman=0.40.0=haf1e3a3_0
+      - pluggy=0.13.1=py36hecd8cb5_0
+      - poppler-data=0.4.10=hecd8cb5_0
       - poppler=0.65.0=ha097c24_1
       - proj4=5.2.0=h0a44026_1
-      - psutil=5.7.0=py36h1de35cc_0
-      - pykdtree=1.3.1=py36h1d22016_2
+      - psutil=5.8.0=py36h9ed2024_1
+      - pykdtree=1.3.4=py36he3068b8_1002
       - pyproj=1.9.6=py36h9c430a6_0
       - pyqt=5.9.2=py36h655552a_2
-      - pyrsistent=0.16.0=py36h1de35cc_0
+      - pyrsistent=0.17.3=py36haf1e3a3_0
+      - pysocks=1.7.1=py36hecd8cb5_0
       - python=3.6.10=hfe9666f_1
-      - pywavelets=1.1.1=py36h1de35cc_0
-      - pyyaml=5.3.1=py36h1de35cc_0
-      - pyzmq=18.1.1=py36h0a44026_0
+      - pyyaml=5.4.1=py36h9ed2024_1
+      - pyzmq=20.0.0=py36h23ab428_1
       - qt=5.9.7=h468cd18_1
       - readline=7.0=h1de35cc_5
-      - scikit-image=0.16.2=py36h6c726b0_0
-      - scipy=1.4.1=py36h9fa6033_0
+      - rtree=0.9.7=py36hecd8cb5_1
+      - scipy=1.5.2=py36h912ce22_0
+      - setuptools=52.0.0=py36hecd8cb5_0
       - shapely=1.6.4=py36he8793f5_0
       - sip=4.19.8=py36h0a44026_0
-      - sqlite=3.31.1=h5c1f38d_1
-      - tbb=2020.0=h04f5b5a_0
-      - tk=8.6.8=ha441bb4_0
-      - tornado=6.0.4=py36h1de35cc_1
-      - xerces-c=3.2.2=h44e365a_0
+      - six=1.15.0=py36hecd8cb5_0
+      - sqlite=3.33.0=hffcf06c_0
+      - terminado=0.9.4=py36hecd8cb5_0
+      - tk=8.6.10=hb0a8c7a_0
+      - tornado=6.1=py36h9ed2024_0
+      - xerces-c=3.2.3=h48eee30_0
       - xz=5.2.5=h1de35cc_0
-      - yaml=0.1.7=hc338f04_2
-      - zeromq=4.3.1=h0a44026_3
+      - yaml=0.2.5=haf1e3a3_0
+      - zeromq=4.3.4=h23ab428_0
       - zlib=1.2.11=h1de35cc_3
-      - zstd=1.3.7=h5bba6e5_0
+      - zstd=1.4.9=h322a384_0
       win-64:
+      - brotlipy=0.7.0=py36h2bbff1b_1003
       - bzip2=1.0.8=he774522_0
-      - cartopy=0.17.0=py36h5ae9855_1
-      - cffi=1.14.0=py36h7a1dbc1_0
-      - cftime=1.1.2=py36h2a96729_0
-      - colorama=0.4.3=py_0
-      - cryptography=2.9.2=py36h7a1dbc1_0
+      - ca-certificates=2021.4.13=haa95532_1
+      - cartopy=0.18.0=py36h80a4efb_1
+      - certifi=2020.12.5=py36haa95532_0
+      - cffi=1.14.5=py36hcd4344a_0
+      - cfitsio=3.470=he774522_6
+      - cftime=1.4.1=py36h080aedc_0
+      - chardet=4.0.0=py36haa95532_1003
+      - cligj=0.7.1=py36haa95532_0
+      - colorama=0.4.4=pyhd3eb1b0_0
+      - cryptography=3.4.7=py36h71e12ea_0
       - curl=7.67.0=h2a8f88b_0
-      - cycler=0.10.0=py36h009560c_0
-      - cytoolz=0.10.1=py36he774522_0
-      - expat=2.2.5=he025d50_0
-      - fiona=1.8.4=py36h22081e2_0
-      - freetype=2.9.1=ha9979f8_1
-      - freexl=1.0.5=hfa6e2cd_0
-      - gdal=2.3.3=py36hdf43c64_0
-      - geos=3.7.1=h33f27b4_0
+      - cycler=0.10.0=py36haa95532_0
+      - cytoolz=0.11.0=py36he774522_0
+      - datashape=0.5.4=py36haa95532_1
+      - distributed=2.30.1=py36haa95532_0
+      - expat=2.3.0=h6c2663c_2
+      - fiona=1.8.13.post1=py36hd760492_0
+      - freetype=2.10.4=hd328e21_0
+      - freexl=1.0.6=h2bbff1b_0
+      - gdal=3.0.2=py36hdf43c64_0
+      - geopandas=0.8.1=py_0
+      - geos=3.8.0=h33f27b4_0
+      - geotiff=1.5.1=h5770a2b_1
       - hdf4=4.2.13=h712560f_2
       - hdf5=1.10.4=h7ebc959_0
       - icc_rt=2019.0.0=h0cc432a_1
       - icu=58.2=ha925a31_3
-      - immutables=0.11=py36he774522_0
-      - intel-openmp=2020.1=216
+      - immutables=0.15=py36h2bbff1b_0
+      - importlib-metadata=3.10.0=py36haa95532_0
+      - intel-openmp=2021.2.0=haa95532_616
       - jpeg=9b=hb83a4c4_2
+      - jupyter_core=4.7.1=py36haa95532_0
       - kealib=1.4.7=h07cbb95_6
-      - kiwisolver=1.2.0=py36h74a9793_0
+      - kiwisolver=1.3.1=py36hd77b12b_0
       - krb5=1.16.4=hc04afaa_0
       - libboost=1.67.0=hd9e427e_4
       - libcurl=7.67.0=h2a8f88b_0
-      - libgdal=2.3.3=h10f50ba_0
+      - libgdal=3.0.2=h1155b67_0
       - libiconv=1.15=h1df5818_7
       - libkml=1.3.0=he5f2a48_4
       - libnetcdf=4.6.1=h411e497_2
       - libpng=1.6.37=h2a8f88b_0
       - libpq=11.2=h3235a2c_0
-      - libsodium=1.0.16=h9d3ae62_0
-      - libspatialindex=1.9.3=h33f27b4_0
-      - libspatialite=4.3.0a=hc36aec2_19
+      - libsodium=1.0.18=h62dcd97_0
+      - libspatialindex=1.9.3=h6c2663c_0
+      - libspatialite=4.3.0a=h7ffb84d_0
       - libssh2=1.9.0=h7a1dbc1_1
       - libtiff=4.1.0=h56a325e_0
-      - libxml2=2.9.9=h464c3ec_0
-      - libxslt=1.1.33=h579f668_0
-      - llvmlite=0.32.1=py36ha925a31_0
-      - locket=0.2.0=py36hfed976d_1
-      - lxml=4.5.0=py36h1350720_0
+      - libxml2=2.9.10=hb89e7f3_3
+      - llvmlite=0.36.0=py36h34b8924_4
+      - locket=0.2.1=py36haa95532_1
+      - lz4-c=1.8.1.2=h2fa13f4_0
+      - m2w64-expat=2.1.1=2
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
+      - m2w64-gettext=0.19.7=2
       - m2w64-gmp=6.1.0=2
+      - m2w64-libiconv=1.14=6
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
-      - markupsafe=1.1.1=py36he774522_0
-      - matplotlib-base=3.1.3=py36h64f37c6_0
+      - m2w64-xz=5.2.2=2
+      - markupsafe=2.0.0=py36h2bbff1b_0
+      - matplotlib-base=3.3.4=py36h49ac443_0
+      - matplotlib=3.3.4=py36haa95532_0
       - mistune=0.8.4=py36he774522_0
-      - mkl-service=2.3.0=py36hb782905_0
-      - mkl=2020.1=216
-      - mkl_fft=1.0.15=py36h14836fe_0
+      - mkl-service=2.3.0=py36h196d8e1_0
+      - mkl=2020.2=256
+      - mkl_fft=1.3.0=py36h46781fe_0
       - mkl_random=1.1.1=py36h47e9c7a_0
-      - msgpack-python=1.0.0=py36h74a9793_1
+      - msgpack-python=1.0.2=py36h59b6b97_1
       - msys2-conda-epoch=20160418=1
       - netcdf4=1.4.2=py36h812ae01_0
-      - numba=0.49.1=py36h47e9c7a_0
-      - numpy-base=1.18.1=py36hc3f5095_1
-      - numpy=1.18.1=py36h93ca92e_0
-      - openssl=1.1.1g=he774522_0
+      - numba=0.53.0=py36hf11a4ad_0
+      - numpy-base=1.19.2=py36ha3acd2a_0
+      - numpy=1.19.2=py36hadc3359_0
+      - openjpeg=2.3.0=h5ec785f_1
+      - openssl=1.1.1k=h2bbff1b_0
       - pandas=0.24.2=py36ha925a31_0
-      - pcre=8.43=ha925a31_0
-      - pillow=7.1.2=py36hcc1f983_0
-      - proj4=5.2.0=ha925a31_1
-      - psutil=5.7.0=py36he774522_0
-      - pykdtree=1.3.1=py36h8c2d366_2
-      - pyproj=1.9.6=py36h6782396_0
+      - pandoc=2.12=haa95532_0
+      - pandocfilters=1.4.3=py36haa95532_1
+      - pcre=8.44=ha925a31_0
+      - pillow=8.2.0=py36h4fa10fc_0
+      - pip=21.0.1=py36haa95532_0
+      - pluggy=0.13.1=py36haa95532_0
+      - postgresql=11.2=h3235a2c_0
+      - proj=6.2.1=h9f7ef89_0
+      - psutil=5.8.0=py36h2bbff1b_1
+      - pyproj=2.6.1.post1=py36h593ac45_1
       - pyqt=5.9.2=py36h6538335_2
-      - pyrsistent=0.16.0=py36he774522_0
-      - python=3.6.10=h9f7ef89_2
-      - pywavelets=1.1.1=py36he774522_0
+      - pyrsistent=0.17.3=py36he774522_0
+      - pysocks=1.7.1=py36haa95532_0
+      - python=3.6.13=h3758d61_0
       - pywin32=227=py36he774522_1
       - pywinpty=0.5.7=py36_0
-      - pyyaml=5.3.1=py36he774522_0
-      - pyzmq=18.1.1=py36ha925a31_0
+      - pyyaml=5.4.1=py36h2bbff1b_1
+      - pyzmq=20.0.0=py36hd77b12b_1
       - qt=5.9.7=vc14h73c81de_0
-      - rtree=0.9.4=py36h21ff451_1
-      - scikit-image=0.16.2=py36h47e9c7a_0
-      - scipy=1.4.1=py36h9439919_0
-      - shapely=1.6.4=py36h222a598_0
+      - rtree=0.9.7=py36h2eaa2aa_1
+      - scipy=1.5.2=py36h9439919_0
+      - setuptools=52.0.0=py36haa95532_0
+      - shapely=1.7.1=py36h210f175_0
       - sip=4.19.8=py36h6538335_0
-      - sqlite=3.31.1=h2a8f88b_1
-      - tbb=2020.0=h74a9793_0
-      - tk=8.6.8=hfa6e2cd_0
-      - tornado=6.0.4=py36he774522_1
-      - vc=14.1=h0510ff6_4
-      - vs2015_runtime=14.16.27012=hf0eaf9b_2
-      - win_inet_pton=1.1.0=py36_0
+      - six=1.15.0=py36haa95532_0
+      - sqlite=3.35.4=h2bbff1b_0
+      - tbb=2018.0.5=he980bc4_0
+      - terminado=0.9.4=py36haa95532_0
+      - tiledb=1.6.3=h7b000aa_0
+      - tk=8.6.10=he774522_0
+      - tornado=6.1=py36h2bbff1b_0
+      - vc=14.2=h21ff451_1
+      - vs2015_runtime=14.27.29016=h5e58377_2
+      - win_inet_pton=1.1.0=py36haa95532_0
       - wincertstore=0.2=py36h7fe50ca_0
       - winpty=0.4.3=4
-      - xerces-c=3.2.2=ha925a31_0
+      - xerces-c=3.2.3=ha925a31_0
       - xz=5.2.5=h62dcd97_0
-      - yaml=0.1.7=hc54c509_2
-      - zeromq=4.3.1=h33f27b4_3
+      - yaml=0.2.5=he774522_0
+      - zeromq=4.3.3=ha925a31_3
       - zlib=1.2.11=h62dcd97_4
       - zstd=1.3.7=h508b16e_0
   default:
     locked: true
-    env_spec_hash: 3c8337cd6744b69a92a60badec9d209be25d94e4
+    env_spec_hash: 0b395d1172970d36177a4ec05cff39f954b36230
     platforms:
     - linux-64
     - osx-64
     - win-64
     packages:
       all:
-      - attrs=19.3.0=py_0
-      - backcall=0.1.0=py36_0
+      - async_generator=1.10=py36h28b3542_0
+      - attrs=21.2.0=pyhd3eb1b0_0
+      - backcall=0.2.0=pyhd3eb1b0_0
       - blas=1.0=mkl
-      - bleach=3.1.4=py_0
-      - bokeh=2.0.2=py36_0
-      - ca-certificates=2020.1.1=0
-      - certifi=2020.4.5.1=py36_0
-      - chardet=3.0.4=py36_1003
+      - bleach=3.3.0=pyhd3eb1b0_0
+      - bokeh=1.4.0=py36_0
       - click-plugins=1.1.1=py_0
-      - click=7.1.2=py_0
-      - cligj=0.5.0=py36_0
-      - cloudpickle=1.4.1=py_0
+      - click=7.1.2=pyhd3eb1b0_0
+      - cloudpickle=1.6.0=py_0
       - colorcet=2.0.1=py_0
       - contextvars=2.4=py_0
-      - dask-core=2.17.0=py_0
-      - dask=2.17.0=py_0
-      - datashader=0.7.0=py_0
-      - datashape=0.5.4=py36_1
-      - decorator=4.4.2=py_0
-      - defusedxml=0.6.0=py_0
-      - distributed=2.17.0=py36_0
+      - dask-core=2.30.0=py_0
+      - dask=2.30.0=py_0
+      - datashader=0.12.1=pyhd3eb1b0_1
+      - decorator=5.0.7=pyhd3eb1b0_0
+      - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py36_0
-      - fsspec=0.7.1=py_0
-      - geopandas=0.6.1=py_0
-      - geoviews-core=1.6.2=py_0
-      - geoviews=1.6.2=py_0
+      - fsspec=0.9.0=pyhd3eb1b0_0
+      - geoviews-core=1.6.6=py_0
+      - geoviews=1.6.6=py_0
       - heapdict=1.0.1=py_0
-      - holoviews=1.12.3=py_2
-      - idna=2.9=py_1
-      - imageio=2.8.0=py_0
-      - importlib-metadata=1.6.0=py36_0
-      - importlib_metadata=1.6.0=0
+      - holoviews=1.12.7=py_0
+      - idna=2.10=pyhd3eb1b0_0
+      - importlib_metadata=3.10.0=hd3eb1b0_0
       - ipykernel=5.1.0=py36h39e3cac_0
-      - ipython=7.13.0=py36h5ca1d4c_0
-      - ipython_genutils=0.2.0=py36_0
-      - ipywidgets=7.5.1=py_0
+      - ipython=7.16.1=py36h5ca1d4c_0
+      - ipython_genutils=0.2.0=pyhd3eb1b0_1
+      - ipywidgets=7.6.3=pyhd3eb1b0_1
       - jedi=0.17.0=py36_0
-      - jinja2=2.11.2=py_0
-      - jsonschema=3.2.0=py36_0
+      - jinja2=3.0.0=pyhd3eb1b0_0
+      - jsonschema=3.2.0=py_2
       - jupyter=1.0.0=py36_7
-      - jupyter_client=6.1.3=py_0
-      - jupyter_console=6.1.0=py_0
-      - jupyter_core=4.6.3=py36_0
-      - matplotlib=3.1.3=py36_0
+      - jupyter_client=6.1.12=pyhd3eb1b0_0
+      - jupyter_console=6.4.0=pyhd3eb1b0_0
+      - jupyterlab_pygments=0.1.2=py_0
+      - jupyterlab_widgets=1.0.0=pyhd3eb1b0_1
       - multipledispatch=0.6.0=py36_0
       - munch=2.5.0=py_0
-      - nbconvert=5.6.1=py36_0
-      - nbformat=5.0.6=py_0
-      - networkx=2.4=py_0
+      - nbclient=0.5.3=pyhd3eb1b0_0
+      - nbconvert=6.0.7=py36_0
+      - nbformat=5.1.3=pyhd3eb1b0_0
+      - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - notebook=5.7.8=py36_0
       - olefile=0.46=py36_0
-      - owslib=0.18.0=py_0
-      - packaging=20.3=py_0
-      - pandoc=2.2.3.2=0
-      - pandocfilters=1.4.2=py36_1
-      - param=1.9.3=py_0
-      - parso=0.7.0=py_0
-      - partd=1.1.0=py_0
-      - pickleshare=0.7.5=py36_0
-      - pip=20.0.2=py36_3
-      - prometheus_client=0.7.1=py_0
-      - prompt-toolkit=3.0.4=py_0
-      - prompt_toolkit=3.0.4=0
-      - pycparser=2.20=py_0
-      - pyct=0.4.6=py36_0
-      - pyepsg=0.4.0=py36_0
-      - pygments=2.6.1=py_0
-      - pyopenssl=19.1.0=py36_0
-      - pyparsing=2.4.7=py_0
-      - pyshp=2.1.0=py_0
-      - pysocks=1.7.1=py36_0
-      - python-dateutil=2.8.1=py_0
-      - pytz=2020.1=py_0
-      - pyviz_comms=0.7.4=py_0
-      - qtconsole=4.7.4=py_0
+      - packaging=20.9=pyhd3eb1b0_0
+      - param=1.9.0=py_0
+      - parso=0.8.2=pyhd3eb1b0_0
+      - partd=1.2.0=pyhd3eb1b0_0
+      - pickleshare=0.7.5=pyhd3eb1b0_1003
+      - prometheus_client=0.10.1=pyhd3eb1b0_0
+      - prompt-toolkit=3.0.17=pyh06a4308_0
+      - prompt_toolkit=3.0.17=hd3eb1b0_0
+      - pycparser=2.20=py_2
+      - pyct=0.4.8=py36_0
+      - pygments=2.8.1=pyhd3eb1b0_0
+      - pyopenssl=20.0.1=pyhd3eb1b0_1
+      - pyparsing=2.4.7=pyhd3eb1b0_0
+      - pyshp=2.1.3=pyhd3eb1b0_0
+      - python-dateutil=2.8.1=pyhd3eb1b0_0
+      - pytz=2021.1=pyhd3eb1b0_0
+      - pyviz_comms=2.0.1=pyhd3eb1b0_0
+      - qtconsole=5.0.3=pyhd3eb1b0_0
       - qtpy=1.9.0=py_0
-      - requests=2.23.0=py36_0
-      - send2trash=1.5.0=py36_0
-      - setuptools=46.4.0=py36_0
-      - six=1.14.0=py36_0
-      - sortedcontainers=2.1.0=py36_0
-      - tblib=1.6.0=py_0
-      - terminado=0.8.3=py36_0
-      - testpath=0.4.4=py_0
-      - toolz=0.10.0=py_0
+      - requests=2.25.1=pyhd3eb1b0_0
+      - send2trash=1.5.0=pyhd3eb1b0_1
+      - sortedcontainers=2.3.0=pyhd3eb1b0_0
+      - tblib=1.7.0=py_0
+      - testpath=0.4.4=pyhd3eb1b0_0
+      - toolz=0.11.1=pyhd3eb1b0_0
       - traitlets=4.3.3=py36_0
-      - typing_extensions=3.7.4.1=py36_0
-      - urllib3=1.25.8=py36_0
-      - wcwidth=0.1.9=py_0
+      - typing_extensions=3.7.4.3=pyha847dfd_0
+      - urllib3=1.26.4=pyhd3eb1b0_0
+      - wcwidth=0.2.5=py_0
       - webencodings=0.5.1=py36_1
-      - wheel=0.34.2=py36_0
+      - wheel=0.36.2=pyhd3eb1b0_0
       - widgetsnbextension=3.5.1=py36_0
       - xarray=0.14.1=py_1
-      - zict=2.0.0=py_0
-      - zipp=3.1.0=py_0
+      - zict=2.0.0=pyhd3eb1b0_0
+      - zipp=3.4.1=pyhd3eb1b0_0
       unix:
-      - pexpect=4.8.0=py36_0
-      - poppler-data=0.4.9=0
-      - ptyprocess=0.6.0=py36_0
-      - rtree=0.9.4=py36_1
+      - geopandas=0.6.1=py_0
+      - owslib=0.18.0=py_0
+      - pexpect=4.8.0=pyhd3eb1b0_3
+      - ptyprocess=0.7.0=pyhd3eb1b0_2
+      - pyepsg=0.4.0=py36_0
       linux-64:
       - _libgcc_mutex=0.1=main
+      - brotlipy=0.7.0=py36h27cfd23_1003
       - bzip2=1.0.8=h7b6447c_0
+      - ca-certificates=2021.4.13=h06a4308_1
       - cairo=1.14.12=h8948797_3
       - cartopy=0.17.0=py36hbb7e04d_1
+      - certifi=2020.12.5=py36h06a4308_0
       - cffi=1.14.0=py36h2e261b9_0
-      - cftime=1.1.2=py36heb32a55_0
-      - cryptography=2.9.2=py36h1ba5d50_0
+      - cftime=1.4.1=py36h6323ea4_0
+      - chardet=4.0.0=py36h06a4308_1003
+      - cligj=0.7.1=py36h06a4308_0
+      - cryptography=3.4.7=py36hd23ed53_0
       - curl=7.67.0=hbc83047_0
       - cycler=0.10.0=py36_0
-      - cytoolz=0.10.1=py36h7b6447c_0
-      - dbus=1.13.14=hb2f20db_0
-      - expat=2.2.6=he6710b0_0
+      - cytoolz=0.11.0=py36h7b6447c_0
+      - datashape=0.5.4=py36h06a4308_1
+      - dbus=1.13.18=hb2f20db_0
+      - distributed=2.30.1=py36h06a4308_0
+      - expat=2.3.0=h2531618_2
       - fiona=1.8.4=py36hc38cc03_0
-      - fontconfig=2.13.0=h9420a91_0
-      - freetype=2.9.1=h8a8886c_1
-      - freexl=1.0.5=h14c3975_0
+      - fontconfig=2.13.1=h6c09931_0
+      - freetype=2.10.4=h5ab3b9f_0
+      - freexl=1.0.6=h27cfd23_0
       - gdal=2.3.3=py36hbb2a789_0
       - geos=3.7.1=he6710b0_0
       - giflib=5.1.4=h14c3975_1
       - glib=2.63.1=h5a9c865_0
-      - gmp=6.1.2=h6c8ec71_1
       - gst-plugins-base=1.14.0=hbbd80ab_1
       - gstreamer=1.14.0=hb453b48_1
       - hdf4=4.2.13=h3ca952b_2
       - hdf5=1.10.4=hb1b8bf9_0
       - icu=58.2=he6710b0_3
-      - immutables=0.11=py36h7b6447c_0
-      - intel-openmp=2020.1=217
+      - immutables=0.15=py36h27cfd23_0
+      - importlib-metadata=3.10.0=py36h06a4308_0
+      - intel-openmp=2021.2.0=h06a4308_610
       - jpeg=9b=h024ee3a_2
       - json-c=0.13.1=h1bed415_0
+      - jupyter_core=4.7.1=py36h06a4308_0
       - kealib=1.4.7=hd0c454d_6
-      - kiwisolver=1.2.0=py36hfd86e86_0
+      - kiwisolver=1.3.1=py36h2531618_0
       - krb5=1.16.4=h173b8e3_0
+      - lcms2=2.12=h3be6417_0
       - ld_impl_linux-64=2.33.1=h53a641e_7
       - libboost=1.67.0=h46d08c1_4
       - libcurl=7.67.0=h20c2e04_0
       - libdap4=3.19.1=h6ec2957_0
-      - libedit=3.1.20181209=hc058e9b_0
-      - libffi=3.2.1=hd88cf55_4
+      - libedit=3.1.20210216=h27cfd23_1
+      - libffi=3.2.1=hf484d3e_1007
       - libgcc-ng=9.1.0=hdf63c60_0
       - libgdal=2.3.3=h2e7e64b_0
       - libgfortran-ng=7.3.0=hdf63c60_0
       - libkml=1.3.0=h590aaf7_4
+      - libllvm10=10.0.1=hbcb73fb_5
       - libnetcdf=4.6.1=h11d0813_2
       - libpng=1.6.37=hbc83047_0
       - libpq=11.2=h20c2e04_0
-      - libsodium=1.0.16=h1bed415_0
-      - libspatialindex=1.9.3=he6710b0_0
+      - libsodium=1.0.18=h7b6447c_0
+      - libspatialindex=1.9.3=h2531618_0
       - libspatialite=4.3.0a=hb08deb6_19
       - libssh2=1.9.0=h1ba5d50_1
       - libstdcxx-ng=9.1.0=hdf63c60_0
-      - libtiff=4.1.0=h2733197_0
+      - libtiff=4.1.0=h2733197_1
       - libuuid=1.0.3=h1bed415_2
-      - libxcb=1.13=h1bed415_1
-      - libxml2=2.9.9=hea5a465_1
-      - libxslt=1.1.33=h7d1a2b0_0
-      - llvmlite=0.32.1=py36hd408876_0
-      - locket=0.2.0=py36_1
-      - lxml=4.5.0=py36hefd8a0e_0
-      - markupsafe=1.1.1=py36h7b6447c_0
-      - matplotlib-base=3.1.3=py36hef1b27d_0
+      - libxcb=1.14=h7b6447c_0
+      - libxml2=2.9.10=hb55368b_3
+      - libxslt=1.1.34=hc22bd24_0
+      - llvmlite=0.36.0=py36h612dafd_4
+      - locket=0.2.1=py36h06a4308_1
+      - lxml=4.6.3=py36h9120a33_0
+      - lz4-c=1.9.3=h2531618_0
+      - markupsafe=2.0.0=py36h27cfd23_0
+      - matplotlib-base=3.3.4=py36h62a2d02_0
+      - matplotlib=3.3.4=py36h06a4308_0
       - mistune=0.8.4=py36h7b6447c_0
-      - mkl-service=2.3.0=py36he904b0f_0
-      - mkl=2020.1=217
-      - mkl_fft=1.0.15=py36ha843d7b_0
+      - mkl-service=2.3.0=py36he8ac12f_0
+      - mkl=2020.2=256
+      - mkl_fft=1.3.0=py36h54f3939_0
       - mkl_random=1.1.1=py36h0573a6f_0
-      - msgpack-python=1.0.0=py36hfd86e86_1
+      - msgpack-python=1.0.2=py36hff7bd54_1
       - ncurses=6.2=he6710b0_1
       - netcdf4=1.4.2=py36h808af73_0
-      - numba=0.49.1=py36h0573a6f_0
-      - numpy-base=1.18.1=py36hde5b4d6_1
-      - numpy=1.18.1=py36h4f9e942_0
+      - numba=0.53.1=py36ha9443f7_0
+      - numpy-base=1.19.2=py36hfa32c7d_0
+      - numpy=1.19.2=py36h54aff64_0
       - openjpeg=2.3.0=h05c96fa_1
-      - openssl=1.1.1g=h7b6447c_0
+      - openssl=1.1.1k=h27cfd23_0
       - pandas=0.24.2=py36he6710b0_0
-      - pcre=8.43=he6710b0_0
-      - pillow=7.1.2=py36hb39fc2d_0
-      - pixman=0.38.0=h7b6447c_0
+      - pandoc=2.12=h06a4308_0
+      - pandocfilters=1.4.3=py36h06a4308_1
+      - pcre=8.44=he6710b0_0
+      - pillow=8.2.0=py36he98fc37_0
+      - pip=21.0.1=py36h06a4308_0
+      - pixman=0.40.0=h7b6447c_0
+      - poppler-data=0.4.10=h06a4308_0
       - poppler=0.65.0=h581218d_1
       - proj4=5.2.0=he6710b0_1
-      - psutil=5.7.0=py36h7b6447c_0
-      - pykdtree=1.3.1=py36hdd07704_2
+      - psutil=5.8.0=py36h27cfd23_1
+      - pykdtree=1.3.4=py36h6323ea4_1002
       - pyproj=1.9.6=py36h14380d9_0
       - pyqt=5.9.2=py36h05f1152_2
-      - pyrsistent=0.16.0=py36h7b6447c_0
+      - pyrsistent=0.17.3=py36h7b6447c_0
+      - pysocks=1.7.1=py36h06a4308_0
       - python=3.6.10=h191fe78_1
-      - pywavelets=1.1.1=py36h7b6447c_0
-      - pyyaml=5.3.1=py36h7b6447c_0
-      - pyzmq=18.1.1=py36he6710b0_0
+      - pyyaml=5.4.1=py36h27cfd23_1
+      - pyzmq=20.0.0=py36h2531618_1
       - qt=5.9.7=h5867ecd_1
       - readline=7.0=h7b6447c_5
-      - scikit-image=0.16.2=py36h0573a6f_0
-      - scipy=1.4.1=py36h0b6359f_0
+      - rtree=0.9.7=py36h06a4308_1
+      - scipy=1.5.2=py36h0b6359f_0
+      - setuptools=52.0.0=py36h06a4308_0
       - shapely=1.6.4=py36h86c5351_0
       - sip=4.19.8=py36hf484d3e_0
-      - sqlite=3.31.1=h62c20be_1
-      - tbb=2020.0=hfd86e86_0
-      - tk=8.6.8=hbc83047_0
-      - tornado=6.0.4=py36h7b6447c_1
-      - xerces-c=3.2.2=h780794e_0
+      - six=1.15.0=py36h06a4308_0
+      - sqlite=3.33.0=h62c20be_0
+      - tbb=2020.3=hfd86e86_0
+      - terminado=0.9.4=py36h06a4308_0
+      - tk=8.6.10=hbc83047_0
+      - tornado=6.1=py36h27cfd23_0
+      - xerces-c=3.2.3=h780794e_0
       - xz=5.2.5=h7b6447c_0
-      - yaml=0.1.7=had09818_2
-      - zeromq=4.3.1=he6710b0_3
+      - yaml=0.2.5=h7b6447c_0
+      - zeromq=4.3.4=h2531618_0
       - zlib=1.2.11=h7b6447c_3
-      - zstd=1.3.7=h0b5b093_0
+      - zstd=1.4.9=haebb681_0
       osx-64:
-      - appnope=0.1.0=py36hf537a9a_0
+      - appnope=0.1.2=py36hecd8cb5_1001
+      - brotlipy=0.7.0=py36h9ed2024_1003
       - bzip2=1.0.8=h1de35cc_0
+      - ca-certificates=2021.4.13=hecd8cb5_1
       - cairo=1.14.12=hc4e6be7_4
       - cartopy=0.17.0=py36haea56ea_1
+      - certifi=2020.12.5=py36hecd8cb5_0
       - cffi=1.14.0=py36hb5b8e2f_0
-      - cftime=1.1.2=py36h776bbcc_0
-      - cryptography=2.9.2=py36ha12b0ac_0
+      - cftime=1.4.1=py36he3068b8_0
+      - chardet=4.0.0=py36hecd8cb5_1003
+      - cligj=0.7.1=py36hecd8cb5_0
+      - cryptography=3.4.7=py36h2fd3fbb_0
       - curl=7.67.0=ha441bb4_0
-      - cycler=0.10.0=py36hfc81398_0
-      - cytoolz=0.10.1=py36h1de35cc_0
-      - dbus=1.13.14=h517e14e_0
-      - expat=2.2.6=h0a44026_0
+      - cycler=0.10.0=py36hecd8cb5_0
+      - cytoolz=0.11.0=py36haf1e3a3_0
+      - datashape=0.5.4=py36hecd8cb5_1
+      - dbus=1.13.18=h18a8e69_0
+      - distributed=2.30.1=py36hecd8cb5_0
+      - expat=2.3.0=h23ab428_2
       - fiona=1.8.4=py36h9a122fd_0
-      - fontconfig=2.13.0=h5d5b041_1
-      - freetype=2.9.1=hb4e5f40_0
-      - freexl=1.0.5=h1de35cc_0
+      - fontconfig=2.13.1=ha9ee91d_0
+      - freetype=2.10.4=ha233b18_0
+      - freexl=1.0.6=h9ed2024_0
       - gdal=2.3.3=py36hbe65578_0
       - geos=3.7.1=h0a44026_0
-      - gettext=0.19.8.1=h15daf44_3
+      - gettext=0.21.0=h7535e17_0
       - giflib=5.1.4=h1de35cc_1
       - glib=2.63.1=hd977a24_0
       - hdf4=4.2.13=h39711bb_2
       - hdf5=1.10.4=hfa1e0ec_0
       - icu=58.2=h0a44026_3
-      - immutables=0.11=py36h1de35cc_0
-      - intel-openmp=2019.4=233
+      - immutables=0.15=py36h9ed2024_0
+      - importlib-metadata=3.10.0=py36hecd8cb5_0
+      - intel-openmp=2021.2.0=hecd8cb5_564
       - jpeg=9b=he5867d9_2
       - json-c=0.13.1=h3efe00b_0
+      - jupyter_core=4.7.1=py36hecd8cb5_0
       - kealib=1.4.7=hf5ed860_6
-      - kiwisolver=1.2.0=py36h04f5b5a_0
+      - kiwisolver=1.3.1=py36h23ab428_0
       - krb5=1.16.4=hddcf347_0
+      - lcms2=2.12=hf1fd2bf_0
       - libboost=1.67.0=hebc422b_4
       - libcurl=7.67.0=h051b688_0
       - libcxx=10.0.0=1
       - libdap4=3.19.1=h3d3e54a_0
-      - libedit=3.1.20181209=hb402a30_0
-      - libffi=3.2.1=h0a44026_6
+      - libedit=3.1.20210216=h9ed2024_1
+      - libffi=3.2.1=h0a44026_1007
       - libgdal=2.3.3=h0950a36_0
       - libgfortran=3.0.1=h93005f0_2
       - libiconv=1.16=h1de35cc_0
       - libkml=1.3.0=hbe12b63_4
+      - libllvm10=10.0.1=h76017ad_5
       - libnetcdf=4.6.1=hd5207e6_2
       - libpng=1.6.37=ha441bb4_0
       - libpq=11.2=h051b688_0
-      - libsodium=1.0.16=h3efe00b_0
-      - libspatialindex=1.9.3=h0a44026_0
+      - libsodium=1.0.18=h1de35cc_0
+      - libspatialindex=1.9.3=h23ab428_0
       - libspatialite=4.3.0a=h644ec7d_19
       - libssh2=1.9.0=ha12b0ac_1
-      - libtiff=4.1.0=hcb84e12_0
-      - libxml2=2.9.9=hf6e021a_1
-      - libxslt=1.1.33=h33a18ac_0
+      - libtiff=4.1.0=hcb84e12_1
+      - libxml2=2.9.10=h7cdb67c_3
+      - libxslt=1.1.34=h83b36ba_0
       - llvm-openmp=10.0.0=h28b9765_0
-      - llvmlite=0.32.1=py36h8c7ce04_0
-      - locket=0.2.0=py36hca03003_1
-      - lxml=4.5.0=py36hef8c89e_0
-      - markupsafe=1.1.1=py36h1de35cc_0
-      - matplotlib-base=3.1.3=py36h9aa3819_0
+      - llvmlite=0.36.0=py36he4411ff_4
+      - locket=0.2.1=py36hecd8cb5_1
+      - lxml=4.6.3=py36h26b266a_0
+      - lz4-c=1.9.3=h23ab428_0
+      - markupsafe=2.0.0=py36h9ed2024_0
+      - matplotlib-base=3.3.4=py36h8b3ea08_0
+      - matplotlib=3.3.4=py36hecd8cb5_0
       - mistune=0.8.4=py36h1de35cc_0
-      - mkl-service=2.3.0=py36hfbe908c_0
+      - mkl-service=2.3.0=py36h9ed2024_0
       - mkl=2019.4=233
-      - mkl_fft=1.0.15=py36h5e564d8_0
+      - mkl_fft=1.3.0=py36ha059aab_0
       - mkl_random=1.1.1=py36h959d312_0
-      - msgpack-python=1.0.0=py36h04f5b5a_1
+      - msgpack-python=1.0.2=py36hf7b0b51_1
       - ncurses=6.2=h0a44026_1
       - netcdf4=1.4.2=py36h13743db_0
-      - numba=0.49.1=py36h86efe34_0
-      - numpy-base=1.18.1=py36h3304bdc_1
-      - numpy=1.18.1=py36h7241aed_0
+      - numba=0.53.0=py36hb2f4e1b_0
+      - numpy-base=1.19.2=py36hcfb5961_0
+      - numpy=1.19.2=py36h456fd55_0
       - openjpeg=2.3.0=hb95cd4c_1
-      - openssl=1.1.1g=h1de35cc_0
+      - openssl=1.1.1k=h9ed2024_0
       - pandas=0.24.2=py36h0a44026_0
-      - pcre=8.43=h0a44026_0
-      - pillow=7.1.2=py36h4655f20_0
-      - pixman=0.38.0=h1de35cc_0
+      - pandoc=2.12=hecd8cb5_0
+      - pandocfilters=1.4.3=py36hecd8cb5_1
+      - pcre=8.44=hb1e8313_0
+      - pillow=8.2.0=py36h5270095_0
+      - pip=21.0.1=py36hecd8cb5_0
+      - pixman=0.40.0=haf1e3a3_0
+      - poppler-data=0.4.10=hecd8cb5_0
       - poppler=0.65.0=ha097c24_1
       - proj4=5.2.0=h0a44026_1
-      - psutil=5.7.0=py36h1de35cc_0
-      - pykdtree=1.3.1=py36h1d22016_2
+      - psutil=5.8.0=py36h9ed2024_1
+      - pykdtree=1.3.4=py36he3068b8_1002
       - pyproj=1.9.6=py36h9c430a6_0
       - pyqt=5.9.2=py36h655552a_2
-      - pyrsistent=0.16.0=py36h1de35cc_0
+      - pyrsistent=0.17.3=py36haf1e3a3_0
+      - pysocks=1.7.1=py36hecd8cb5_0
       - python=3.6.10=hfe9666f_1
-      - pywavelets=1.1.1=py36h1de35cc_0
-      - pyyaml=5.3.1=py36h1de35cc_0
-      - pyzmq=18.1.1=py36h0a44026_0
+      - pyyaml=5.4.1=py36h9ed2024_1
+      - pyzmq=20.0.0=py36h23ab428_1
       - qt=5.9.7=h468cd18_1
       - readline=7.0=h1de35cc_5
-      - scikit-image=0.16.2=py36h6c726b0_0
-      - scipy=1.4.1=py36h9fa6033_0
+      - rtree=0.9.7=py36hecd8cb5_1
+      - scipy=1.5.2=py36h912ce22_0
+      - setuptools=52.0.0=py36hecd8cb5_0
       - shapely=1.6.4=py36he8793f5_0
       - sip=4.19.8=py36h0a44026_0
-      - sqlite=3.31.1=h5c1f38d_1
-      - tbb=2020.0=h04f5b5a_0
-      - tk=8.6.8=ha441bb4_0
-      - tornado=6.0.4=py36h1de35cc_1
-      - xerces-c=3.2.2=h44e365a_0
+      - six=1.15.0=py36hecd8cb5_0
+      - sqlite=3.33.0=hffcf06c_0
+      - terminado=0.9.4=py36hecd8cb5_0
+      - tk=8.6.10=hb0a8c7a_0
+      - tornado=6.1=py36h9ed2024_0
+      - xerces-c=3.2.3=h48eee30_0
       - xz=5.2.5=h1de35cc_0
-      - yaml=0.1.7=hc338f04_2
-      - zeromq=4.3.1=h0a44026_3
+      - yaml=0.2.5=haf1e3a3_0
+      - zeromq=4.3.4=h23ab428_0
       - zlib=1.2.11=h1de35cc_3
-      - zstd=1.3.7=h5bba6e5_0
+      - zstd=1.4.9=h322a384_0
       win-64:
+      - brotlipy=0.7.0=py36h2bbff1b_1003
       - bzip2=1.0.8=he774522_0
-      - cartopy=0.17.0=py36h5ae9855_1
-      - cffi=1.14.0=py36h7a1dbc1_0
-      - cftime=1.1.2=py36h2a96729_0
-      - colorama=0.4.3=py_0
-      - cryptography=2.9.2=py36h7a1dbc1_0
+      - ca-certificates=2021.4.13=haa95532_1
+      - cartopy=0.18.0=py36h80a4efb_1
+      - certifi=2020.12.5=py36haa95532_0
+      - cffi=1.14.5=py36hcd4344a_0
+      - cfitsio=3.470=he774522_6
+      - cftime=1.4.1=py36h080aedc_0
+      - chardet=4.0.0=py36haa95532_1003
+      - cligj=0.7.1=py36haa95532_0
+      - colorama=0.4.4=pyhd3eb1b0_0
+      - cryptography=3.4.7=py36h71e12ea_0
       - curl=7.67.0=h2a8f88b_0
-      - cycler=0.10.0=py36h009560c_0
-      - cytoolz=0.10.1=py36he774522_0
-      - expat=2.2.5=he025d50_0
-      - fiona=1.8.4=py36h22081e2_0
-      - freetype=2.9.1=ha9979f8_1
-      - freexl=1.0.5=hfa6e2cd_0
-      - gdal=2.3.3=py36hdf43c64_0
-      - geos=3.7.1=h33f27b4_0
+      - cycler=0.10.0=py36haa95532_0
+      - cytoolz=0.11.0=py36he774522_0
+      - datashape=0.5.4=py36haa95532_1
+      - distributed=2.30.1=py36haa95532_0
+      - expat=2.3.0=h6c2663c_2
+      - fiona=1.8.13.post1=py36hd760492_0
+      - freetype=2.10.4=hd328e21_0
+      - freexl=1.0.6=h2bbff1b_0
+      - gdal=3.0.2=py36hdf43c64_0
+      - geopandas=0.8.1=py_0
+      - geos=3.8.0=h33f27b4_0
+      - geotiff=1.5.1=h5770a2b_1
       - hdf4=4.2.13=h712560f_2
       - hdf5=1.10.4=h7ebc959_0
       - icc_rt=2019.0.0=h0cc432a_1
       - icu=58.2=ha925a31_3
-      - immutables=0.11=py36he774522_0
-      - intel-openmp=2020.1=216
+      - immutables=0.15=py36h2bbff1b_0
+      - importlib-metadata=3.10.0=py36haa95532_0
+      - intel-openmp=2021.2.0=haa95532_616
       - jpeg=9b=hb83a4c4_2
+      - jupyter_core=4.7.1=py36haa95532_0
       - kealib=1.4.7=h07cbb95_6
-      - kiwisolver=1.2.0=py36h74a9793_0
+      - kiwisolver=1.3.1=py36hd77b12b_0
       - krb5=1.16.4=hc04afaa_0
       - libboost=1.67.0=hd9e427e_4
       - libcurl=7.67.0=h2a8f88b_0
-      - libgdal=2.3.3=h10f50ba_0
+      - libgdal=3.0.2=h1155b67_0
       - libiconv=1.15=h1df5818_7
       - libkml=1.3.0=he5f2a48_4
       - libnetcdf=4.6.1=h411e497_2
       - libpng=1.6.37=h2a8f88b_0
       - libpq=11.2=h3235a2c_0
-      - libsodium=1.0.16=h9d3ae62_0
-      - libspatialindex=1.9.3=h33f27b4_0
-      - libspatialite=4.3.0a=hc36aec2_19
+      - libsodium=1.0.18=h62dcd97_0
+      - libspatialindex=1.9.3=h6c2663c_0
+      - libspatialite=4.3.0a=h7ffb84d_0
       - libssh2=1.9.0=h7a1dbc1_1
       - libtiff=4.1.0=h56a325e_0
-      - libxml2=2.9.9=h464c3ec_0
-      - libxslt=1.1.33=h579f668_0
-      - llvmlite=0.32.1=py36ha925a31_0
-      - locket=0.2.0=py36hfed976d_1
-      - lxml=4.5.0=py36h1350720_0
+      - libxml2=2.9.10=hb89e7f3_3
+      - llvmlite=0.36.0=py36h34b8924_4
+      - locket=0.2.1=py36haa95532_1
+      - lz4-c=1.8.1.2=h2fa13f4_0
+      - m2w64-expat=2.1.1=2
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
+      - m2w64-gettext=0.19.7=2
       - m2w64-gmp=6.1.0=2
+      - m2w64-libiconv=1.14=6
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
-      - markupsafe=1.1.1=py36he774522_0
-      - matplotlib-base=3.1.3=py36h64f37c6_0
+      - m2w64-xz=5.2.2=2
+      - markupsafe=2.0.0=py36h2bbff1b_0
+      - matplotlib-base=3.3.4=py36h49ac443_0
+      - matplotlib=3.3.4=py36haa95532_0
       - mistune=0.8.4=py36he774522_0
-      - mkl-service=2.3.0=py36hb782905_0
-      - mkl=2020.1=216
-      - mkl_fft=1.0.15=py36h14836fe_0
+      - mkl-service=2.3.0=py36h196d8e1_0
+      - mkl=2020.2=256
+      - mkl_fft=1.3.0=py36h46781fe_0
       - mkl_random=1.1.1=py36h47e9c7a_0
-      - msgpack-python=1.0.0=py36h74a9793_1
+      - msgpack-python=1.0.2=py36h59b6b97_1
       - msys2-conda-epoch=20160418=1
       - netcdf4=1.4.2=py36h812ae01_0
-      - numba=0.49.1=py36h47e9c7a_0
-      - numpy-base=1.18.1=py36hc3f5095_1
-      - numpy=1.18.1=py36h93ca92e_0
-      - openssl=1.1.1g=he774522_0
+      - numba=0.53.0=py36hf11a4ad_0
+      - numpy-base=1.19.2=py36ha3acd2a_0
+      - numpy=1.19.2=py36hadc3359_0
+      - openjpeg=2.3.0=h5ec785f_1
+      - openssl=1.1.1k=h2bbff1b_0
       - pandas=0.24.2=py36ha925a31_0
-      - pcre=8.43=ha925a31_0
-      - pillow=7.1.2=py36hcc1f983_0
-      - proj4=5.2.0=ha925a31_1
-      - psutil=5.7.0=py36he774522_0
-      - pykdtree=1.3.1=py36h8c2d366_2
-      - pyproj=1.9.6=py36h6782396_0
+      - pandoc=2.12=haa95532_0
+      - pandocfilters=1.4.3=py36haa95532_1
+      - pcre=8.44=ha925a31_0
+      - pillow=8.2.0=py36h4fa10fc_0
+      - pip=21.0.1=py36haa95532_0
+      - postgresql=11.2=h3235a2c_0
+      - proj=6.2.1=h9f7ef89_0
+      - psutil=5.8.0=py36h2bbff1b_1
+      - pyproj=2.6.1.post1=py36h593ac45_1
       - pyqt=5.9.2=py36h6538335_2
-      - pyrsistent=0.16.0=py36he774522_0
-      - python=3.6.10=h9f7ef89_2
-      - pywavelets=1.1.1=py36he774522_0
+      - pyrsistent=0.17.3=py36he774522_0
+      - pysocks=1.7.1=py36haa95532_0
+      - python=3.6.13=h3758d61_0
       - pywin32=227=py36he774522_1
       - pywinpty=0.5.7=py36_0
-      - pyyaml=5.3.1=py36he774522_0
-      - pyzmq=18.1.1=py36ha925a31_0
+      - pyyaml=5.4.1=py36h2bbff1b_1
+      - pyzmq=20.0.0=py36hd77b12b_1
       - qt=5.9.7=vc14h73c81de_0
-      - rtree=0.9.4=py36h21ff451_1
-      - scikit-image=0.16.2=py36h47e9c7a_0
-      - scipy=1.4.1=py36h9439919_0
-      - shapely=1.6.4=py36h222a598_0
+      - rtree=0.9.7=py36h2eaa2aa_1
+      - scipy=1.5.2=py36h9439919_0
+      - setuptools=52.0.0=py36haa95532_0
+      - shapely=1.7.1=py36h210f175_0
       - sip=4.19.8=py36h6538335_0
-      - sqlite=3.31.1=h2a8f88b_1
-      - tbb=2020.0=h74a9793_0
-      - tk=8.6.8=hfa6e2cd_0
-      - tornado=6.0.4=py36he774522_1
-      - vc=14.1=h0510ff6_4
-      - vs2015_runtime=14.16.27012=hf0eaf9b_2
-      - win_inet_pton=1.1.0=py36_0
+      - six=1.15.0=py36haa95532_0
+      - sqlite=3.35.4=h2bbff1b_0
+      - tbb=2018.0.5=he980bc4_0
+      - terminado=0.9.4=py36haa95532_0
+      - tiledb=1.6.3=h7b000aa_0
+      - tk=8.6.10=he774522_0
+      - tornado=6.1=py36h2bbff1b_0
+      - vc=14.2=h21ff451_1
+      - vs2015_runtime=14.27.29016=h5e58377_2
+      - win_inet_pton=1.1.0=py36haa95532_0
       - wincertstore=0.2=py36h7fe50ca_0
       - winpty=0.4.3=4
-      - xerces-c=3.2.2=ha925a31_0
+      - xerces-c=3.2.3=ha925a31_0
       - xz=5.2.5=h62dcd97_0
-      - yaml=0.1.7=hc54c509_2
-      - zeromq=4.3.1=h33f27b4_3
+      - yaml=0.2.5=he774522_0
+      - zeromq=4.3.3=ha925a31_3
       - zlib=1.2.11=h62dcd97_4
       - zstd=1.3.7=h508b16e_0
+
+

--- a/bay_trimesh/anaconda-project.yml
+++ b/bay_trimesh/anaconda-project.yml
@@ -16,10 +16,13 @@ packages: &pkgs
 - notebook=5.7.8
 - ipykernel=5.1.0
 - colorcet=2.0.1
-- datashader=0.7.0
-- geoviews=1.6.2
-- holoviews=1.12.3
+- datashader=0.12.1
+- geoviews=1.6.6
+- holoviews=1.12.7
 - pandas=0.24.2
+- bokeh=1.4.0
+- dask=2.3.0
+- param=1.9.0
 
 dependencies: *pkgs
 


### PR DESCRIPTION
This PR updates the bay_trimesh notebook to work with the current stack (including dask dataframes if using the workaround in https://github.com/holoviz/holoviews/issues/4927).