### PR TITLE
Updated attractors.ipynb to use hvplot and Panel

### DIFF
--- a/attractors/anaconda-project-lock.yml
+++ b/attractors/anaconda-project-lock.yml
@@ -17,7 +17,7 @@ locking_enabled: true
 env_specs:
   test:
     locked: true
-    env_spec_hash: f4754db9d2eb2686248ed993d9d52f6117c02b5a
+    env_spec_hash: c05aeba8ddbcf58853b8df42513c3b784153545c
     platforms:
     - linux-64
     - osx-64
@@ -41,9 +41,10 @@ env_specs:
       - decorator=5.0.9=pyhd3eb1b0_0
       - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py37_0
-      - fsspec=2021.6.0=pyhd3eb1b0_0
+      - fsspec=2021.7.0=pyhd3eb1b0_0
       - heapdict=1.0.1=py_0
-      - holoviews=1.14.4=py_0
+      - holoviews=1.14.5=py_0
+      - hvplot=0.8.0a7=py_0
       - idna=2.10=pyhd3eb1b0_0
       - importlib_metadata=3.10.0=hd3eb1b0_0
       - ipykernel=5.3.4=py37h5ca1d4c_0
@@ -61,8 +62,8 @@ env_specs:
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - olefile=0.46=py37_0
       - packaging=21.0=pyhd3eb1b0_0
-      - panel=0.11.3=py_0
-      - param=1.11.1=py_0
+      - panel=0.12.0rc11=py_0
+      - param=1.11.2a1=py_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
       - pickleshare=0.7.5=pyhd3eb1b0_1003
@@ -352,7 +353,7 @@ env_specs:
       - zstd=1.4.9=h19a0ad4_0
   default:
     locked: true
-    env_spec_hash: bb8dcb1b584f9f91982a5532713fee39e24d44b4
+    env_spec_hash: ea7f9eb3d9ab32c55634878c379904b4f52dceeb
     platforms:
     - linux-64
     - osx-64
@@ -374,9 +375,10 @@ env_specs:
       - decorator=5.0.9=pyhd3eb1b0_0
       - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py37_0
-      - fsspec=2021.6.0=pyhd3eb1b0_0
+      - fsspec=2021.7.0=pyhd3eb1b0_0
       - heapdict=1.0.1=py_0
-      - holoviews=1.14.4=py_0
+      - holoviews=1.14.5=py_0
+      - hvplot=0.8.0a7=py_0
       - idna=2.10=pyhd3eb1b0_0
       - importlib_metadata=3.10.0=hd3eb1b0_0
       - ipykernel=5.3.4=py37h5ca1d4c_0
@@ -392,8 +394,8 @@ env_specs:
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - olefile=0.46=py37_0
       - packaging=21.0=pyhd3eb1b0_0
-      - panel=0.11.3=py_0
-      - param=1.11.1=py_0
+      - panel=0.12.0rc11=py_0
+      - param=1.11.2a1=py_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
       - pickleshare=0.7.5=pyhd3eb1b0_1003

--- a/attractors/anaconda-project.yml
+++ b/attractors/anaconda-project.yml
@@ -8,7 +8,7 @@ labels:
 - panel
 
 channels:
-- pyviz
+- pyviz/label/dev
 
 user_fields: [labels, skip, maintainers]
 
@@ -24,6 +24,7 @@ packages: &pkgs
 - holoviews
 - panel
 - param
+- hvplot
 
 dependencies: *pkgs
 

--- a/attractors/attractors.ipynb
+++ b/attractors/attractors.ipynb
@@ -424,7 +424,7 @@
    "source": [
     "## Interactive plotting\n",
     "\n",
-    "If you are running a live Python process, you can use Datashader with HoloViews and Bokeh to zoom in and see the individual steps in any of these calculations:"
+    "If you are running a live Python process, you can use Datashader with [hvPlot](https://hvplot.holoviz.org) to zoom in and see the individual steps in any of these calculations using a [Bokeh](https://bokeh.org) plot:"
    ]
   },
   {
@@ -433,12 +433,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import holoviews as hv\n",
-    "from holoviews.operation.datashader import rasterize, dynspread\n",
-    "hv.extension('bokeh')\n",
+    "import hvplot.pandas\n",
     "\n",
-    "pts = hv.Points(trajectory(Clifford, *(args(\"Clifford\")[5][1:])))\n",
-    "dynspread(rasterize(pts).opts(cnorm='eq_hist', width=400,height=400))"
+    "df = trajectory(Clifford, *(args(\"Clifford\")[5][1:]))\n",
+    "opts = dict(rasterize=True, dynspread=True, cnorm='eq_hist', width=400, height=400, colorbar=False)\n",
+    "\n",
+    "df.hvplot.scatter(x='x', y='y', **opts)"
    ]
   },
   {
@@ -456,8 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pth = hv.Path([trajectory(Clifford, *(args(\"Clifford\")[5][1:]))])\n",
-    "dynspread(rasterize(pth).opts(cnorm='eq_hist', width=400,height=400))"
+    "df.hvplot.line(x='x', y='y', **opts)"
    ]
   },
   {
@@ -466,7 +465,7 @@
    "source": [
     "Again, if you zoom in on a live server, the plot will update so that you can see the individual traces involved. \n",
     "\n",
-    "On the live server, you can also explore to find your own parameter values that generate interesting patterns:"
+    "On the live server, you can also explore to find your own parameter values that generate interesting patterns. Here we've made a tiny [Panel](https://panel.holoviz.org) app to regenerate the values given each parameter value, then plot the result:"
    ]
   },
   {
@@ -476,22 +475,20 @@
    "outputs": [],
    "source": [
     "def hv_clif(a,b,c,d,x0=0,y0=0,n=n):\n",
-    "    return hv.Points(trajectory(Clifford, x0, y0, a, b, c, d, n))\n",
+    "    df = trajectory(Clifford, x0, y0, a, b, c, d, n)\n",
+    "    return df.hvplot.scatter(x='x', y='y', **opts)\n",
     "\n",
-    "x0,y0,a,b,c,d = args(\"Clifford\")[6][1:]\n",
-    "\n",
-    "dm = hv.DynamicMap(hv_clif, kdims=['a', 'b', 'c', 'd'])\n",
-    "dm = dm.redim.range(a=(-2.0, 2.0), b=(-2.0,2.0), c=(-2.0,2.0), d=(-2.0,2.0))\n",
-    "dm = dm.redim.default(a=a, b=b, c=c, d=d)\n",
-    "\n",
-    "dynspread(rasterize(dm)).opts(cmap='kgy_r', cnorm='eq_hist', width=500,height=500)"
+    "import panel as pn\n",
+    "init = zip(['a', 'b', 'c', 'd'], args(\"Clifford\")[6][-4:])\n",
+    "widgets = [pn.widgets.FloatSlider(name=n, start=-2.0, end=2.0, value=v) for n,v in init]\n",
+    "pn.Row(pn.bind(hv_clif, *widgets), pn.Column(*widgets))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although many of the regions of this four-dimensional parameter space generate uninteresting trajectories such as single points, you can find interesting regions by starting with one of the _a,b,c,d_ tuples of values in previous plots, then click on one slider and use the left and right arrow keys to see how the plot changes as that parameter changes. See also this [Panel](http://panel.pyviz.org)-based [attractor dashboard](https://anaconda.org/jbednar/datashaderattractors)."
+    "Although many of the regions of this four-dimensional parameter space generate uninteresting trajectories such as single points, you can find interesting regions by starting with one of the _a,b,c,d_ tuples of values in previous Clifford plots, then click on one slider and use the left and right arrow keys to see how the plot changes as that parameter changes. See also this more ambitious [Panel](http://panel.pyviz.org)-based [attractor dashboard](https://examples.pyviz.org/attractors/attractors_panel.html)."
    ]
   }
  ],


### PR DESCRIPTION
As an exercise in our new [hvPlot-centric approach to using our tools](https://github.com/holoviz/hvplot/issues/533), I've updated attractors.ipynb to use  hvplot and Panel instead of hv and DynamicMap. The goal isn't necessarily to make the code shorter, though it did reduce it slightly, it's to make the concepts easier to convey given what people already know about Pandas and how widgets work.

I *think* it's succeeded at that?  Certainly the first couple of .hvplot calls are straightforward; there is data in a df, and we call hvplot on it. 

The last example is less of a clear win. We can't use .interactive here because we're generating a new DataFrame each time, so I've used Panel and pn.bind. The old one only relied on HoloViews concepts throughout, from hv.Points to DynamicMap, which means that there was one place to go for reference, but even so the ideas were quite esoteric and surprising to people.  The new one adds Panel widgets and pn.bind as concepts, which they do have to figure out, but I think they are easier to convey and it's also much, much clearer where to go from here. The user can see that if they wanted to put anything else on a widget, they can just define one and hook it in, whereas with DynamicMap it was unclear how to add a Boolean, Selector, etc.

The new code in that last cell is also somewhat dense, but I can't think of any easy way to simplify it without making it much, much more verbose.