### PR TITLE
Refactored exoplanets into modular plotting functions

### DIFF
--- a/exoplanets/anaconda-project-lock.yml
+++ b/exoplanets/anaconda-project-lock.yml
@@ -62,7 +62,7 @@ env_specs:
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - olefile=0.46=py37_0
       - packaging=20.9=pyhd3eb1b0_0
-      - panel=0.11.3=pyhd3eb1b0_0
+      - panel=0.12.0=pyhd3eb1b0_0
       - param=1.10.1=pyhd3eb1b0_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
@@ -376,7 +376,7 @@ env_specs:
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - olefile=0.46=py37_0
       - packaging=20.9=pyhd3eb1b0_0
-      - panel=0.11.3=pyhd3eb1b0_0
+      - panel=0.12.0=pyhd3eb1b0_0
       - param=1.10.1=pyhd3eb1b0_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0

--- a/exoplanets/anaconda-project-lock.yml
+++ b/exoplanets/anaconda-project-lock.yml
@@ -17,7 +17,7 @@ locking_enabled: true
 env_specs:
   test:
     locked: true
-    env_spec_hash: f60dac520cebeeab3dd101dba1feed578f724bc4
+    env_spec_hash: 85e3d0f14dcec067036f9cff63ea9a37aa0ed2dd
     platforms:
     - linux-64
     - osx-64
@@ -30,30 +30,30 @@ env_specs:
       - backcall=0.2.0=pyhd3eb1b0_0
       - beautifulsoup4=4.9.3=pyha847dfd_0
       - blas=1.0=mkl
-      - bleach=3.3.0=pyhd3eb1b0_0
+      - bleach=4.0.0=pyhd3eb1b0_0
       - click=8.0.1=pyhd3eb1b0_0
       - cloudpickle=1.6.0=py_0
       - colorcet=2.0.6=pyhd3eb1b0_0
       - cycler=0.10.0=py37_0
-      - dask-core=2021.6.2=pyhd3eb1b0_0
-      - dask=2021.6.2=pyhd3eb1b0_0
+      - dask-core=2021.7.2=pyhd3eb1b0_0
+      - dask=2021.7.2=pyhd3eb1b0_0
       - datashader=0.13.0=pyhd3eb1b0_1
       - decorator=5.0.9=pyhd3eb1b0_0
       - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py37_0
-      - fsspec=2021.6.0=pyhd3eb1b0_0
+      - fsspec=2021.7.0=pyhd3eb1b0_0
       - heapdict=1.0.1=py_0
-      - holoviews=1.14.4=pyhd3eb1b0_1
-      - hvplot=0.7.2=pyhd3eb1b0_1
+      - holoviews=1.14.5=pyhd3eb1b0_1
+      - hvplot=0.7.3=pyhd3eb1b0_1
       - idna=2.10=pyhd3eb1b0_0
       - importlib_metadata=3.10.0=hd3eb1b0_0
       - ipykernel=5.3.4=py37h5ca1d4c_0
       - ipython_genutils=0.2.0=pyhd3eb1b0_1
-      - jedi=0.17.0=py37_0
-      - jinja2=3.0.0=pyhd3eb1b0_0
+      - jinja2=3.0.1=pyhd3eb1b0_0
       - jsonschema=3.2.0=py_2
       - jupyter_client=6.1.12=pyhd3eb1b0_0
       - jupyterlab_pygments=0.1.2=py_0
+      - matplotlib-inline=0.1.2=pyhd3eb1b0_2
       - more-itertools=8.8.0=pyhd3eb1b0_0
       - multipledispatch=0.6.0=py37_0
       - nbclient=0.5.3=pyhd3eb1b0_0
@@ -61,9 +61,9 @@ env_specs:
       - nbsmoke=0.2.8=py37_0
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - olefile=0.46=py37_0
-      - packaging=20.9=pyhd3eb1b0_0
+      - packaging=21.0=pyhd3eb1b0_0
       - panel=0.12.0=pyhd3eb1b0_0
-      - param=1.10.1=pyhd3eb1b0_0
+      - param=1.11.1=pyhd3eb1b0_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
       - pickleshare=0.7.5=pyhd3eb1b0_1003
@@ -77,7 +77,7 @@ env_specs:
       - pyopenssl=20.0.1=pyhd3eb1b0_1
       - pyparsing=2.4.7=pyhd3eb1b0_0
       - pytest=4.4.1=py37_0
-      - python-dateutil=2.8.1=pyhd3eb1b0_0
+      - python-dateutil=2.8.2=pyhd3eb1b0_0
       - pytz=2021.1=pyhd3eb1b0_0
       - pyviz_comms=2.0.2=pyhd3eb1b0_0
       - requests=2.25.1=pyhd3eb1b0_0
@@ -88,88 +88,105 @@ env_specs:
       - tblib=1.7.0=py_0
       - testpath=0.5.0=pyhd3eb1b0_0
       - toolz=0.11.1=pyhd3eb1b0_0
-      - tqdm=4.61.1=pyhd3eb1b0_1
+      - tqdm=4.62.0=pyhd3eb1b0_1
       - traitlets=5.0.5=pyhd3eb1b0_0
-      - typing_extensions=3.7.4.3=pyha847dfd_0
-      - urllib3=1.26.4=pyhd3eb1b0_0
+      - typing-extensions=3.10.0.0=hd3eb1b0_0
+      - typing_extensions=3.10.0.0=pyh06a4308_0
+      - urllib3=1.26.6=pyhd3eb1b0_1
       - wcwidth=0.2.5=py_0
       - webencodings=0.5.1=py37_1
       - wheel=0.36.2=pyhd3eb1b0_0
-      - xarray=0.18.0=pyhd3eb1b0_1
+      - xarray=0.19.0=pyhd3eb1b0_1
       - zict=2.0.0=pyhd3eb1b0_0
-      - zipp=3.4.1=pyhd3eb1b0_0
+      - zipp=3.5.0=pyhd3eb1b0_0
       unix:
       - pexpect=4.8.0=pyhd3eb1b0_3
       - ptyprocess=0.7.0=pyhd3eb1b0_2
       linux-64:
       - _libgcc_mutex=0.1=main
-      - _openmp_mutex=4.5=1_gnu
       - argon2-cffi=20.1.0=py37h27cfd23_1
-      - astropy=4.2.1=py37h6323ea4_1
-      - bokeh=2.3.2=py37h06a4308_0
+      - astropy=4.3.post1=py37hce1f21e_1
+      - bokeh=2.3.3=py37h06a4308_0
+      - bottleneck=1.3.2=py37heb32a55_1
       - brotlipy=0.7.0=py37h27cfd23_1003
-      - ca-certificates=2021.5.25=h06a4308_1
+      - ca-certificates=2021.7.5=h06a4308_1
       - certifi=2021.5.30=py37h06a4308_0
-      - cffi=1.14.5=py37h261ae71_0
+      - cffi=1.14.6=py37h400218f_0
       - chardet=4.0.0=py37h06a4308_1003
       - cryptography=3.4.7=py37hd23ed53_0
       - cytoolz=0.11.0=py37h7b6447c_0
       - datashape=0.5.4=py37h06a4308_1
-      - distributed=2021.6.2=py37h06a4308_0
+      - dbus=1.13.18=hb2f20db_0
+      - distributed=2021.7.2=py37h06a4308_0
+      - expat=2.4.1=h2531618_2
+      - fontconfig=2.13.1=h6c09931_0
       - freetype=2.10.4=h5ab3b9f_0
+      - glib=2.69.0=h5202010_0
+      - gst-plugins-base=1.14.0=h8213a91_2
+      - gstreamer=1.14.0=h28cd5cc_2
+      - icu=58.2=he6710b0_3
       - importlib-metadata=3.10.0=py37h06a4308_0
-      - intel-openmp=2021.2.0=h06a4308_610
-      - ipython=7.22.0=py37hb070fc8_0
+      - intel-openmp=2021.3.0=h06a4308_3350
+      - ipython=7.26.0=py37hb070fc8_0
+      - jedi=0.18.0=py37h06a4308_1
       - jpeg=9b=h024ee3a_2
       - jupyter_core=4.7.1=py37h06a4308_0
       - kiwisolver=1.3.1=py37h2531618_0
       - lcms2=2.12=h3be6417_0
       - ld_impl_linux-64=2.35.1=h7274673_9
       - libffi=3.3=he6710b0_2
-      - libgcc-ng=9.3.0=h5101ec6_17
-      - libgfortran-ng=7.5.0=ha8ba4b0_17
-      - libgfortran4=7.5.0=ha8ba4b0_17
-      - libgomp=9.3.0=h5101ec6_17
+      - libgcc-ng=9.1.0=hdf63c60_0
+      - libgfortran-ng=7.3.0=hdf63c60_0
       - libllvm10=10.0.1=hbcb73fb_5
       - libpng=1.6.37=hbc83047_0
       - libsodium=1.0.18=h7b6447c_0
-      - libstdcxx-ng=9.3.0=hd4cf53a_17
+      - libstdcxx-ng=9.1.0=hdf63c60_0
       - libtiff=4.2.0=h85742a9_0
+      - libuuid=1.0.3=h1bed415_2
       - libwebp-base=1.2.0=h27cfd23_0
+      - libxcb=1.14=h7b6447c_0
+      - libxml2=2.9.10=hb55368b_3
       - llvmlite=0.36.0=py37h612dafd_4
       - locket=0.2.1=py37h06a4308_1
-      - lz4-c=1.9.3=h2531618_0
+      - lz4-c=1.9.3=h295c915_1
       - markdown=3.3.4=py37h06a4308_0
       - markupsafe=2.0.1=py37h27cfd23_0
       - matplotlib-base=3.3.4=py37h62a2d02_0
+      - matplotlib=3.3.4=py37h06a4308_0
       - mistune=0.8.4=py37h14c3975_1001
-      - mkl-service=2.3.0=py37h27cfd23_1
-      - mkl=2021.2.0=h06a4308_296
+      - mkl-service=2.4.0=py37h7f8727e_0
+      - mkl=2021.3.0=h06a4308_520
       - mkl_fft=1.3.0=py37h42c9631_2
-      - mkl_random=1.2.1=py37ha9443f7_2
+      - mkl_random=1.2.2=py37h51133e4_0
       - msgpack-python=1.0.2=py37hff7bd54_1
       - nbconvert=6.1.0=py37h06a4308_0
       - ncurses=6.2=he6710b0_1
-      - notebook=6.4.0=py37h06a4308_0
+      - notebook=6.4.1=py37h06a4308_0
       - numba=0.53.1=py37ha9443f7_0
-      - numpy-base=1.20.2=py37hfae3a4d_0
-      - numpy=1.20.2=py37h2d18471_0
+      - numexpr=2.7.3=py37h22e1b3c_1
+      - numpy-base=1.20.3=py37h74d4b33_0
+      - numpy=1.20.3=py37hf144106_0
+      - openjpeg=2.3.0=h05c96fa_1
       - openssl=1.1.1k=h27cfd23_0
-      - pandas=1.2.5=py37h295c915_0
+      - pandas=1.3.1=py37h8c16a72_0
       - pandocfilters=1.4.3=py37h06a4308_1
-      - pillow=8.2.0=py37he98fc37_0
-      - pip=21.1.2=py37h06a4308_0
+      - pcre=8.45=h295c915_0
+      - pillow=8.3.1=py37h2c7a002_0
+      - pip=21.2.2=py37h06a4308_0
       - pluggy=0.13.1=py37h06a4308_0
       - psutil=5.8.0=py37h27cfd23_1
       - pyerfa=2.0.0=py37h27cfd23_0
+      - pyqt=5.9.2=py37h05f1152_2
       - pyrsistent=0.17.3=py37h7b6447c_0
       - pysocks=1.7.1=py37_1
-      - python=3.7.10=h12debd9_4
+      - python=3.7.11=h12debd9_0
       - pyyaml=5.4.1=py37h27cfd23_1
       - pyzmq=20.0.0=py37h2531618_1
+      - qt=5.9.7=h5867ecd_1
       - readline=8.1=h27cfd23_0
       - scipy=1.6.2=py37had2a1c9_1
       - setuptools=52.0.0=py37h06a4308_0
+      - sip=4.19.8=py37hf484d3e_0
       - sqlite=3.36.0=hc218d9a_0
       - tbb=2020.3=hfd86e86_0
       - terminado=0.9.4=py37h06a4308_0
@@ -183,21 +200,25 @@ env_specs:
       osx-64:
       - appnope=0.1.2=py37hecd8cb5_1001
       - argon2-cffi=20.1.0=py37h9ed2024_1
-      - astropy=4.2.1=py37he3068b8_1
-      - bokeh=2.3.2=py37hecd8cb5_0
+      - astropy=4.3.post1=py37he3068b8_1
+      - bokeh=2.3.3=py37hecd8cb5_0
+      - bottleneck=1.3.2=py37hf1fa96c_1
+      - brotli=1.0.9=hb1e8313_2
       - brotlipy=0.7.0=py37h9ed2024_1003
-      - ca-certificates=2021.5.25=hecd8cb5_1
+      - ca-certificates=2021.7.5=hecd8cb5_1
       - certifi=2021.5.30=py37hecd8cb5_0
-      - cffi=1.14.5=py37h2125817_0
+      - cffi=1.14.6=py37h2125817_0
       - chardet=4.0.0=py37hecd8cb5_1003
       - cryptography=3.4.7=py37h2fd3fbb_0
       - cytoolz=0.11.0=py37haf1e3a3_0
       - datashape=0.5.4=py37hecd8cb5_1
-      - distributed=2021.6.2=py37hecd8cb5_0
+      - distributed=2021.7.2=py37hecd8cb5_0
+      - fonttools=4.25.0=pyhd3eb1b0_0
       - freetype=2.10.4=ha233b18_0
       - importlib-metadata=3.10.0=py37hecd8cb5_0
-      - intel-openmp=2021.2.0=hecd8cb5_564
-      - ipython=7.22.0=py37h01d92e1_0
+      - intel-openmp=2021.3.0=hecd8cb5_3375
+      - ipython=7.26.0=py37h01d92e1_0
+      - jedi=0.18.0=py37hecd8cb5_1
       - jpeg=9b=he5867d9_2
       - jupyter_core=4.7.1=py37hecd8cb5_0
       - kiwisolver=1.3.1=py37h23ab428_0
@@ -213,33 +234,37 @@ env_specs:
       - llvm-openmp=10.0.0=h28b9765_0
       - llvmlite=0.36.0=py37he4411ff_4
       - locket=0.2.1=py37hecd8cb5_1
-      - lz4-c=1.9.3=h23ab428_0
+      - lz4-c=1.9.3=h23ab428_1
       - markdown=3.3.4=py37hecd8cb5_0
       - markupsafe=2.0.1=py37h9ed2024_0
-      - matplotlib-base=3.3.4=py37h8b3ea08_0
+      - matplotlib-base=3.4.2=py37h8b3ea08_0
+      - matplotlib=3.4.2=py37hecd8cb5_0
       - mistune=0.8.4=py37h1de35cc_0
-      - mkl-service=2.3.0=py37h9ed2024_1
-      - mkl=2021.2.0=hecd8cb5_269
+      - mkl-service=2.4.0=py37h9ed2024_0
+      - mkl=2021.3.0=hecd8cb5_517
       - mkl_fft=1.3.0=py37h4a7008c_2
-      - mkl_random=1.2.1=py37hb2f4e1b_2
+      - mkl_random=1.2.2=py37hb2f4e1b_0
       - msgpack-python=1.0.2=py37hf7b0b51_1
+      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37hecd8cb5_0
       - ncurses=6.2=h0a44026_1
-      - notebook=6.4.0=py37hecd8cb5_0
+      - notebook=6.4.1=py37hecd8cb5_0
       - numba=0.53.0=py37hb2f4e1b_0
-      - numpy-base=1.20.2=py37he0bd621_0
-      - numpy=1.20.2=py37h4b4dc7a_0
+      - numexpr=2.7.3=py37h5873af2_1
+      - numpy-base=1.20.3=py37he0bd621_0
+      - numpy=1.20.3=py37h4b4dc7a_0
+      - openjpeg=2.3.0=hb95cd4c_1
       - openssl=1.1.1k=h9ed2024_0
-      - pandas=1.2.5=py37h23ab428_0
+      - pandas=1.3.1=py37h5008ddb_0
       - pandocfilters=1.4.3=py37hecd8cb5_1
-      - pillow=8.2.0=py37h5270095_0
-      - pip=21.1.2=py37hecd8cb5_0
+      - pillow=8.3.1=py37ha4cf6ea_0
+      - pip=21.2.2=py37hecd8cb5_0
       - pluggy=0.13.1=py37hecd8cb5_0
       - psutil=5.8.0=py37h9ed2024_1
       - pyerfa=2.0.0=py37h9ed2024_0
       - pyrsistent=0.17.3=py37haf1e3a3_0
       - pysocks=1.7.1=py37hecd8cb5_0
-      - python=3.7.10=h88f2d9e_0
+      - python=3.7.11=h88f2d9e_0
       - pyyaml=5.4.1=py37h9ed2024_1
       - pyzmq=20.0.0=py37h23ab428_1
       - readline=8.1=h9ed2024_0
@@ -256,23 +281,28 @@ env_specs:
       - zstd=1.4.9=h322a384_0
       win-64:
       - argon2-cffi=20.1.0=py37h2bbff1b_1
-      - astropy=4.2.1=py37h080aedc_1
-      - bokeh=2.3.2=py37haa95532_0
+      - astropy=4.3.post1=py37h080aedc_1
+      - bokeh=2.3.3=py37haa95532_0
+      - bottleneck=1.3.2=py37h2a96729_1
+      - brotli=1.0.9=ha925a31_2
       - brotlipy=0.7.0=py37h2bbff1b_1003
-      - ca-certificates=2021.5.25=haa95532_1
+      - ca-certificates=2021.7.5=haa95532_1
       - certifi=2021.5.30=py37haa95532_0
-      - cffi=1.14.5=py37hcd4344a_0
+      - cffi=1.14.6=py37h2bbff1b_0
       - chardet=4.0.0=py37haa95532_1003
       - colorama=0.4.4=pyhd3eb1b0_0
       - cryptography=3.4.7=py37h71e12ea_0
       - cytoolz=0.11.0=py37he774522_0
       - datashape=0.5.4=py37haa95532_1
-      - distributed=2021.6.2=py37haa95532_0
+      - distributed=2021.7.2=py37haa95532_0
+      - fonttools=4.25.0=pyhd3eb1b0_0
       - freetype=2.10.4=hd328e21_0
       - icc_rt=2019.0.0=h0cc432a_1
+      - icu=58.2=ha925a31_3
       - importlib-metadata=3.10.0=py37haa95532_0
-      - intel-openmp=2021.2.0=haa95532_616
-      - ipython=7.22.0=py37hd4e2768_0
+      - intel-openmp=2021.3.0=haa95532_3372
+      - ipython=7.26.0=py37hd4e2768_0
+      - jedi=0.18.0=py37haa95532_1
       - jpeg=9b=hb83a4c4_2
       - jupyter_core=4.7.1=py37haa95532_0
       - kiwisolver=1.3.1=py37hd77b12b_0
@@ -281,7 +311,7 @@ env_specs:
       - libtiff=4.2.0=hd0e1b90_0
       - llvmlite=0.36.0=py37h34b8924_4
       - locket=0.2.1=py37haa95532_1
-      - lz4-c=1.9.3=h2bbff1b_0
+      - lz4-c=1.9.3=h2bbff1b_1
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
@@ -289,36 +319,42 @@ env_specs:
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
       - markdown=3.3.4=py37haa95532_0
       - markupsafe=2.0.1=py37h2bbff1b_0
-      - matplotlib-base=3.3.4=py37h49ac443_0
+      - matplotlib-base=3.4.2=py37h49ac443_0
+      - matplotlib=3.4.2=py37haa95532_0
       - mistune=0.8.4=py37hfa6e2cd_1001
-      - mkl-service=2.3.0=py37h2bbff1b_1
-      - mkl=2021.2.0=haa95532_296
+      - mkl-service=2.4.0=py37h2bbff1b_0
+      - mkl=2021.3.0=haa95532_524
       - mkl_fft=1.3.0=py37h277e83a_2
-      - mkl_random=1.2.1=py37hf11a4ad_2
+      - mkl_random=1.2.2=py37hf11a4ad_0
       - msgpack-python=1.0.2=py37h59b6b97_1
       - msys2-conda-epoch=20160418=1
+      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37haa95532_0
-      - notebook=6.4.0=py37haa95532_0
+      - notebook=6.4.1=py37haa95532_0
       - numba=0.53.0=py37hf11a4ad_0
-      - numpy-base=1.20.2=py37hc2deb75_0
-      - numpy=1.20.2=py37ha4e8547_0
+      - numexpr=2.7.3=py37hb80d3ca_1
+      - numpy-base=1.20.3=py37hc2deb75_0
+      - numpy=1.20.3=py37ha4e8547_0
       - openssl=1.1.1k=h2bbff1b_0
-      - pandas=1.2.5=py37hd77b12b_0
+      - pandas=1.3.1=py37h6214cd6_0
       - pandocfilters=1.4.3=py37haa95532_1
-      - pillow=8.2.0=py37h4fa10fc_0
-      - pip=21.1.2=py37haa95532_0
+      - pillow=8.3.1=py37h4fa10fc_0
+      - pip=21.2.2=py37haa95532_0
       - pluggy=0.13.1=py37haa95532_0
       - psutil=5.8.0=py37h2bbff1b_1
       - pyerfa=2.0.0=py37h2bbff1b_0
+      - pyqt=5.9.2=py37h6538335_2
       - pyrsistent=0.17.3=py37he774522_0
       - pysocks=1.7.1=py37_1
-      - python=3.7.10=h6244533_0
-      - pywin32=227=py37he774522_1
+      - python=3.7.11=h6244533_0
+      - pywin32=228=py37hbaba5e8_1
       - pywinpty=0.5.7=py37_0
       - pyyaml=5.4.1=py37h2bbff1b_1
       - pyzmq=20.0.0=py37hd77b12b_1
+      - qt=5.9.7=vc14h73c81de_0
       - scipy=1.6.2=py37h66253e8_1
       - setuptools=52.0.0=py37haa95532_0
+      - sip=4.19.8=py37h6538335_0
       - sqlite=3.36.0=h2bbff1b_0
       - terminado=0.9.4=py37haa95532_0
       - tk=8.6.10=he774522_0
@@ -335,7 +371,7 @@ env_specs:
       - zstd=1.4.9=h19a0ad4_0
   default:
     locked: true
-    env_spec_hash: e63a2562ec758d5c90ad643e95a7f07b91c636af
+    env_spec_hash: 37160f249b52878c03f213ddd53d11e348e6f2e0
     platforms:
     - linux-64
     - osx-64
@@ -346,38 +382,38 @@ env_specs:
       - attrs=21.2.0=pyhd3eb1b0_0
       - backcall=0.2.0=pyhd3eb1b0_0
       - blas=1.0=mkl
-      - bleach=3.3.0=pyhd3eb1b0_0
+      - bleach=4.0.0=pyhd3eb1b0_0
       - click=8.0.1=pyhd3eb1b0_0
       - cloudpickle=1.6.0=py_0
       - colorcet=2.0.6=pyhd3eb1b0_0
       - cycler=0.10.0=py37_0
-      - dask-core=2021.6.2=pyhd3eb1b0_0
-      - dask=2021.6.2=pyhd3eb1b0_0
+      - dask-core=2021.7.2=pyhd3eb1b0_0
+      - dask=2021.7.2=pyhd3eb1b0_0
       - datashader=0.13.0=pyhd3eb1b0_1
       - decorator=5.0.9=pyhd3eb1b0_0
       - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py37_0
-      - fsspec=2021.6.0=pyhd3eb1b0_0
+      - fsspec=2021.7.0=pyhd3eb1b0_0
       - heapdict=1.0.1=py_0
-      - holoviews=1.14.4=pyhd3eb1b0_1
-      - hvplot=0.7.2=pyhd3eb1b0_1
+      - holoviews=1.14.5=pyhd3eb1b0_1
+      - hvplot=0.7.3=pyhd3eb1b0_1
       - idna=2.10=pyhd3eb1b0_0
       - importlib_metadata=3.10.0=hd3eb1b0_0
       - ipykernel=5.3.4=py37h5ca1d4c_0
       - ipython_genutils=0.2.0=pyhd3eb1b0_1
-      - jedi=0.17.0=py37_0
-      - jinja2=3.0.0=pyhd3eb1b0_0
+      - jinja2=3.0.1=pyhd3eb1b0_0
       - jsonschema=3.2.0=py_2
       - jupyter_client=6.1.12=pyhd3eb1b0_0
       - jupyterlab_pygments=0.1.2=py_0
+      - matplotlib-inline=0.1.2=pyhd3eb1b0_2
       - multipledispatch=0.6.0=py37_0
       - nbclient=0.5.3=pyhd3eb1b0_0
       - nbformat=5.1.3=pyhd3eb1b0_0
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
       - olefile=0.46=py37_0
-      - packaging=20.9=pyhd3eb1b0_0
+      - packaging=21.0=pyhd3eb1b0_0
       - panel=0.12.0=pyhd3eb1b0_0
-      - param=1.10.1=pyhd3eb1b0_0
+      - param=1.11.1=pyhd3eb1b0_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
       - pickleshare=0.7.5=pyhd3eb1b0_1003
@@ -388,7 +424,7 @@ env_specs:
       - pygments=2.9.0=pyhd3eb1b0_0
       - pyopenssl=20.0.1=pyhd3eb1b0_1
       - pyparsing=2.4.7=pyhd3eb1b0_0
-      - python-dateutil=2.8.1=pyhd3eb1b0_0
+      - python-dateutil=2.8.2=pyhd3eb1b0_0
       - pytz=2021.1=pyhd3eb1b0_0
       - pyviz_comms=2.0.2=pyhd3eb1b0_0
       - requests=2.25.1=pyhd3eb1b0_0
@@ -398,87 +434,104 @@ env_specs:
       - tblib=1.7.0=py_0
       - testpath=0.5.0=pyhd3eb1b0_0
       - toolz=0.11.1=pyhd3eb1b0_0
-      - tqdm=4.61.1=pyhd3eb1b0_1
+      - tqdm=4.62.0=pyhd3eb1b0_1
       - traitlets=5.0.5=pyhd3eb1b0_0
-      - typing_extensions=3.7.4.3=pyha847dfd_0
-      - urllib3=1.26.4=pyhd3eb1b0_0
+      - typing-extensions=3.10.0.0=hd3eb1b0_0
+      - typing_extensions=3.10.0.0=pyh06a4308_0
+      - urllib3=1.26.6=pyhd3eb1b0_1
       - wcwidth=0.2.5=py_0
       - webencodings=0.5.1=py37_1
       - wheel=0.36.2=pyhd3eb1b0_0
-      - xarray=0.18.0=pyhd3eb1b0_1
+      - xarray=0.19.0=pyhd3eb1b0_1
       - zict=2.0.0=pyhd3eb1b0_0
-      - zipp=3.4.1=pyhd3eb1b0_0
+      - zipp=3.5.0=pyhd3eb1b0_0
       unix:
       - pexpect=4.8.0=pyhd3eb1b0_3
       - ptyprocess=0.7.0=pyhd3eb1b0_2
       linux-64:
       - _libgcc_mutex=0.1=main
-      - _openmp_mutex=4.5=1_gnu
       - argon2-cffi=20.1.0=py37h27cfd23_1
-      - astropy=4.2.1=py37h6323ea4_1
-      - bokeh=2.3.2=py37h06a4308_0
+      - astropy=4.3.post1=py37hce1f21e_1
+      - bokeh=2.3.3=py37h06a4308_0
+      - bottleneck=1.3.2=py37heb32a55_1
       - brotlipy=0.7.0=py37h27cfd23_1003
-      - ca-certificates=2021.5.25=h06a4308_1
+      - ca-certificates=2021.7.5=h06a4308_1
       - certifi=2021.5.30=py37h06a4308_0
-      - cffi=1.14.5=py37h261ae71_0
+      - cffi=1.14.6=py37h400218f_0
       - chardet=4.0.0=py37h06a4308_1003
       - cryptography=3.4.7=py37hd23ed53_0
       - cytoolz=0.11.0=py37h7b6447c_0
       - datashape=0.5.4=py37h06a4308_1
-      - distributed=2021.6.2=py37h06a4308_0
+      - dbus=1.13.18=hb2f20db_0
+      - distributed=2021.7.2=py37h06a4308_0
+      - expat=2.4.1=h2531618_2
+      - fontconfig=2.13.1=h6c09931_0
       - freetype=2.10.4=h5ab3b9f_0
+      - glib=2.69.0=h5202010_0
+      - gst-plugins-base=1.14.0=h8213a91_2
+      - gstreamer=1.14.0=h28cd5cc_2
+      - icu=58.2=he6710b0_3
       - importlib-metadata=3.10.0=py37h06a4308_0
-      - intel-openmp=2021.2.0=h06a4308_610
-      - ipython=7.22.0=py37hb070fc8_0
+      - intel-openmp=2021.3.0=h06a4308_3350
+      - ipython=7.26.0=py37hb070fc8_0
+      - jedi=0.18.0=py37h06a4308_1
       - jpeg=9b=h024ee3a_2
       - jupyter_core=4.7.1=py37h06a4308_0
       - kiwisolver=1.3.1=py37h2531618_0
       - lcms2=2.12=h3be6417_0
       - ld_impl_linux-64=2.35.1=h7274673_9
       - libffi=3.3=he6710b0_2
-      - libgcc-ng=9.3.0=h5101ec6_17
-      - libgfortran-ng=7.5.0=ha8ba4b0_17
-      - libgfortran4=7.5.0=ha8ba4b0_17
-      - libgomp=9.3.0=h5101ec6_17
+      - libgcc-ng=9.1.0=hdf63c60_0
+      - libgfortran-ng=7.3.0=hdf63c60_0
       - libllvm10=10.0.1=hbcb73fb_5
       - libpng=1.6.37=hbc83047_0
       - libsodium=1.0.18=h7b6447c_0
-      - libstdcxx-ng=9.3.0=hd4cf53a_17
+      - libstdcxx-ng=9.1.0=hdf63c60_0
       - libtiff=4.2.0=h85742a9_0
+      - libuuid=1.0.3=h1bed415_2
       - libwebp-base=1.2.0=h27cfd23_0
+      - libxcb=1.14=h7b6447c_0
+      - libxml2=2.9.10=hb55368b_3
       - llvmlite=0.36.0=py37h612dafd_4
       - locket=0.2.1=py37h06a4308_1
-      - lz4-c=1.9.3=h2531618_0
+      - lz4-c=1.9.3=h295c915_1
       - markdown=3.3.4=py37h06a4308_0
       - markupsafe=2.0.1=py37h27cfd23_0
       - matplotlib-base=3.3.4=py37h62a2d02_0
+      - matplotlib=3.3.4=py37h06a4308_0
       - mistune=0.8.4=py37h14c3975_1001
-      - mkl-service=2.3.0=py37h27cfd23_1
-      - mkl=2021.2.0=h06a4308_296
+      - mkl-service=2.4.0=py37h7f8727e_0
+      - mkl=2021.3.0=h06a4308_520
       - mkl_fft=1.3.0=py37h42c9631_2
-      - mkl_random=1.2.1=py37ha9443f7_2
+      - mkl_random=1.2.2=py37h51133e4_0
       - msgpack-python=1.0.2=py37hff7bd54_1
       - nbconvert=6.1.0=py37h06a4308_0
       - ncurses=6.2=he6710b0_1
-      - notebook=6.4.0=py37h06a4308_0
+      - notebook=6.4.1=py37h06a4308_0
       - numba=0.53.1=py37ha9443f7_0
-      - numpy-base=1.20.2=py37hfae3a4d_0
-      - numpy=1.20.2=py37h2d18471_0
+      - numexpr=2.7.3=py37h22e1b3c_1
+      - numpy-base=1.20.3=py37h74d4b33_0
+      - numpy=1.20.3=py37hf144106_0
+      - openjpeg=2.3.0=h05c96fa_1
       - openssl=1.1.1k=h27cfd23_0
-      - pandas=1.2.5=py37h295c915_0
+      - pandas=1.3.1=py37h8c16a72_0
       - pandocfilters=1.4.3=py37h06a4308_1
-      - pillow=8.2.0=py37he98fc37_0
-      - pip=21.1.2=py37h06a4308_0
+      - pcre=8.45=h295c915_0
+      - pillow=8.3.1=py37h2c7a002_0
+      - pip=21.2.2=py37h06a4308_0
       - psutil=5.8.0=py37h27cfd23_1
       - pyerfa=2.0.0=py37h27cfd23_0
+      - pyqt=5.9.2=py37h05f1152_2
       - pyrsistent=0.17.3=py37h7b6447c_0
       - pysocks=1.7.1=py37_1
-      - python=3.7.10=h12debd9_4
+      - python=3.7.11=h12debd9_0
       - pyyaml=5.4.1=py37h27cfd23_1
       - pyzmq=20.0.0=py37h2531618_1
+      - qt=5.9.7=h5867ecd_1
       - readline=8.1=h27cfd23_0
       - scipy=1.6.2=py37had2a1c9_1
       - setuptools=52.0.0=py37h06a4308_0
+      - sip=4.19.8=py37hf484d3e_0
       - sqlite=3.36.0=hc218d9a_0
       - tbb=2020.3=hfd86e86_0
       - terminado=0.9.4=py37h06a4308_0
@@ -492,21 +545,25 @@ env_specs:
       osx-64:
       - appnope=0.1.2=py37hecd8cb5_1001
       - argon2-cffi=20.1.0=py37h9ed2024_1
-      - astropy=4.2.1=py37he3068b8_1
-      - bokeh=2.3.2=py37hecd8cb5_0
+      - astropy=4.3.post1=py37he3068b8_1
+      - bokeh=2.3.3=py37hecd8cb5_0
+      - bottleneck=1.3.2=py37hf1fa96c_1
+      - brotli=1.0.9=hb1e8313_2
       - brotlipy=0.7.0=py37h9ed2024_1003
-      - ca-certificates=2021.5.25=hecd8cb5_1
+      - ca-certificates=2021.7.5=hecd8cb5_1
       - certifi=2021.5.30=py37hecd8cb5_0
-      - cffi=1.14.5=py37h2125817_0
+      - cffi=1.14.6=py37h2125817_0
       - chardet=4.0.0=py37hecd8cb5_1003
       - cryptography=3.4.7=py37h2fd3fbb_0
       - cytoolz=0.11.0=py37haf1e3a3_0
       - datashape=0.5.4=py37hecd8cb5_1
-      - distributed=2021.6.2=py37hecd8cb5_0
+      - distributed=2021.7.2=py37hecd8cb5_0
+      - fonttools=4.25.0=pyhd3eb1b0_0
       - freetype=2.10.4=ha233b18_0
       - importlib-metadata=3.10.0=py37hecd8cb5_0
-      - intel-openmp=2021.2.0=hecd8cb5_564
-      - ipython=7.22.0=py37h01d92e1_0
+      - intel-openmp=2021.3.0=hecd8cb5_3375
+      - ipython=7.26.0=py37h01d92e1_0
+      - jedi=0.18.0=py37hecd8cb5_1
       - jpeg=9b=he5867d9_2
       - jupyter_core=4.7.1=py37hecd8cb5_0
       - kiwisolver=1.3.1=py37h23ab428_0
@@ -522,38 +579,43 @@ env_specs:
       - llvm-openmp=10.0.0=h28b9765_0
       - llvmlite=0.36.0=py37he4411ff_4
       - locket=0.2.1=py37hecd8cb5_1
-      - lz4-c=1.9.3=h23ab428_0
+      - lz4-c=1.9.3=h23ab428_1
       - markdown=3.3.4=py37hecd8cb5_0
       - markupsafe=2.0.1=py37h9ed2024_0
-      - matplotlib-base=3.3.4=py37h8b3ea08_0
+      - matplotlib-base=3.4.2=py37h8b3ea08_0
+      - matplotlib=3.4.2=py37hecd8cb5_0
       - mistune=0.8.4=py37h1de35cc_0
-      - mkl-service=2.3.0=py37h9ed2024_1
-      - mkl=2021.2.0=hecd8cb5_269
+      - mkl-service=2.4.0=py37h9ed2024_0
+      - mkl=2021.3.0=hecd8cb5_517
       - mkl_fft=1.3.0=py37h4a7008c_2
-      - mkl_random=1.2.1=py37hb2f4e1b_2
+      - mkl_random=1.2.2=py37hb2f4e1b_0
       - msgpack-python=1.0.2=py37hf7b0b51_1
+      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37hecd8cb5_0
       - ncurses=6.2=h0a44026_1
-      - notebook=6.4.0=py37hecd8cb5_0
-      - numba=0.53.0=py37hb2f4e1b_0
-      - numpy-base=1.20.2=py37he0bd621_0
-      - numpy=1.20.2=py37h4b4dc7a_0
+      - notebook=6.4.1=py37hecd8cb5_0
+      - numba=0.53.1=py37hb2f4e1b_0
+      - numexpr=2.7.3=py37h5873af2_1
+      - numpy-base=1.20.3=py37he0bd621_0
+      - numpy=1.20.3=py37h4b4dc7a_0
+      - openjpeg=2.3.0=hb95cd4c_1
       - openssl=1.1.1k=h9ed2024_0
-      - pandas=1.2.5=py37h23ab428_0
+      - pandas=1.3.1=py37h5008ddb_0
       - pandocfilters=1.4.3=py37hecd8cb5_1
-      - pillow=8.2.0=py37h5270095_0
-      - pip=21.1.2=py37hecd8cb5_0
+      - pillow=8.3.1=py37ha4cf6ea_0
+      - pip=21.2.2=py37hecd8cb5_0
       - psutil=5.8.0=py37h9ed2024_1
       - pyerfa=2.0.0=py37h9ed2024_0
       - pyrsistent=0.17.3=py37haf1e3a3_0
       - pysocks=1.7.1=py37hecd8cb5_0
-      - python=3.7.10=h88f2d9e_0
+      - python=3.7.11=h88f2d9e_0
       - pyyaml=5.4.1=py37h9ed2024_1
       - pyzmq=20.0.0=py37h23ab428_1
       - readline=8.1=h9ed2024_0
       - scipy=1.6.2=py37hd5f7400_1
       - setuptools=52.0.0=py37hecd8cb5_0
       - sqlite=3.36.0=hce871da_0
+      - tbb=2020.3=h879752b_0
       - terminado=0.9.4=py37hecd8cb5_0
       - tk=8.6.10=hb0a8c7a_0
       - tornado=6.1=py37h9ed2024_0
@@ -564,23 +626,28 @@ env_specs:
       - zstd=1.4.9=h322a384_0
       win-64:
       - argon2-cffi=20.1.0=py37h2bbff1b_1
-      - astropy=4.2.1=py37h080aedc_1
-      - bokeh=2.3.2=py37haa95532_0
+      - astropy=4.3.post1=py37h080aedc_1
+      - bokeh=2.3.3=py37haa95532_0
+      - bottleneck=1.3.2=py37h2a96729_1
+      - brotli=1.0.9=ha925a31_2
       - brotlipy=0.7.0=py37h2bbff1b_1003
-      - ca-certificates=2021.5.25=haa95532_1
+      - ca-certificates=2021.7.5=haa95532_1
       - certifi=2021.5.30=py37haa95532_0
-      - cffi=1.14.5=py37hcd4344a_0
+      - cffi=1.14.6=py37h2bbff1b_0
       - chardet=4.0.0=py37haa95532_1003
       - colorama=0.4.4=pyhd3eb1b0_0
       - cryptography=3.4.7=py37h71e12ea_0
       - cytoolz=0.11.0=py37he774522_0
       - datashape=0.5.4=py37haa95532_1
-      - distributed=2021.6.2=py37haa95532_0
+      - distributed=2021.7.2=py37haa95532_0
+      - fonttools=4.25.0=pyhd3eb1b0_0
       - freetype=2.10.4=hd328e21_0
       - icc_rt=2019.0.0=h0cc432a_1
+      - icu=58.2=ha925a31_3
       - importlib-metadata=3.10.0=py37haa95532_0
-      - intel-openmp=2021.2.0=haa95532_616
-      - ipython=7.22.0=py37hd4e2768_0
+      - intel-openmp=2021.3.0=haa95532_3372
+      - ipython=7.26.0=py37hd4e2768_0
+      - jedi=0.18.0=py37haa95532_1
       - jpeg=9b=hb83a4c4_2
       - jupyter_core=4.7.1=py37haa95532_0
       - kiwisolver=1.3.1=py37hd77b12b_0
@@ -589,7 +656,7 @@ env_specs:
       - libtiff=4.2.0=hd0e1b90_0
       - llvmlite=0.36.0=py37h34b8924_4
       - locket=0.2.1=py37haa95532_1
-      - lz4-c=1.9.3=h2bbff1b_0
+      - lz4-c=1.9.3=h2bbff1b_1
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
       - m2w64-gcc-libs=5.3.0=7
@@ -597,36 +664,43 @@ env_specs:
       - m2w64-libwinpthread-git=5.0.0.4634.697f757=2
       - markdown=3.3.4=py37haa95532_0
       - markupsafe=2.0.1=py37h2bbff1b_0
-      - matplotlib-base=3.3.4=py37h49ac443_0
+      - matplotlib-base=3.4.2=py37h49ac443_0
+      - matplotlib=3.4.2=py37haa95532_0
       - mistune=0.8.4=py37hfa6e2cd_1001
-      - mkl-service=2.3.0=py37h2bbff1b_1
-      - mkl=2021.2.0=haa95532_296
+      - mkl-service=2.4.0=py37h2bbff1b_0
+      - mkl=2021.3.0=haa95532_524
       - mkl_fft=1.3.0=py37h277e83a_2
-      - mkl_random=1.2.1=py37hf11a4ad_2
+      - mkl_random=1.2.2=py37hf11a4ad_0
       - msgpack-python=1.0.2=py37h59b6b97_1
       - msys2-conda-epoch=20160418=1
+      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37haa95532_0
-      - notebook=6.4.0=py37haa95532_0
-      - numba=0.53.0=py37hf11a4ad_0
-      - numpy-base=1.20.2=py37hc2deb75_0
-      - numpy=1.20.2=py37ha4e8547_0
+      - notebook=6.4.1=py37haa95532_0
+      - numba=0.53.1=py37hf11a4ad_0
+      - numexpr=2.7.3=py37hb80d3ca_1
+      - numpy-base=1.20.3=py37hc2deb75_0
+      - numpy=1.20.3=py37ha4e8547_0
       - openssl=1.1.1k=h2bbff1b_0
-      - pandas=1.2.5=py37hd77b12b_0
+      - pandas=1.3.1=py37h6214cd6_0
       - pandocfilters=1.4.3=py37haa95532_1
-      - pillow=8.2.0=py37h4fa10fc_0
-      - pip=21.1.2=py37haa95532_0
+      - pillow=8.3.1=py37h4fa10fc_0
+      - pip=21.2.2=py37haa95532_0
       - psutil=5.8.0=py37h2bbff1b_1
       - pyerfa=2.0.0=py37h2bbff1b_0
+      - pyqt=5.9.2=py37h6538335_2
       - pyrsistent=0.17.3=py37he774522_0
       - pysocks=1.7.1=py37_1
-      - python=3.7.10=h6244533_0
-      - pywin32=227=py37he774522_1
+      - python=3.7.11=h6244533_0
+      - pywin32=228=py37hbaba5e8_1
       - pywinpty=0.5.7=py37_0
       - pyyaml=5.4.1=py37h2bbff1b_1
       - pyzmq=20.0.0=py37hd77b12b_1
+      - qt=5.9.7=vc14h73c81de_0
       - scipy=1.6.2=py37h66253e8_1
       - setuptools=52.0.0=py37haa95532_0
+      - sip=4.19.8=py37h6538335_0
       - sqlite=3.36.0=h2bbff1b_0
+      - tbb=2020.3=h74a9793_0
       - terminado=0.9.4=py37haa95532_0
       - tk=8.6.10=he774522_0
       - tornado=6.1=py37h2bbff1b_0

--- a/exoplanets/anaconda-project.yml
+++ b/exoplanets/anaconda-project.yml
@@ -15,10 +15,11 @@ channels: []
 packages: &pkgs
   - python=3.7
   - notebook
-  - panel
   - ipykernel
+  - panel
   - bokeh
   - hvplot
+  - holoviews
   - pandas
   - datashader
   - astropy

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -7,8 +7,8 @@
    "source": [
     "# Exoplanets\n",
     "Written by Blythe Davis<br>\n",
-    "Created July 23, 2021<br>\n",
-    "Last updated: August 10, 2021"
+    "Created: July 23, 2021<br>\n",
+    "Last updated: August 12, 2021"
    ]
   },
   {
@@ -291,7 +291,7 @@
    "id": "f2520ec7",
    "metadata": {},
    "source": [
-    "One of the first things that jumps out about this plot is the dark curve separating the two clusters of stars. This dark curve represents our section of the Milky Way.\n",
+    "One of the first things that jumps out about this plot is the dark curve separating the two clusters of stars. This dark curve represents the [ecliptic](https://earthsky.org/space/what-is-the-ecliptic), the circular tilted path traveled by the sun, projected onto a plane.\n",
     "\n",
     "Now let's plot the planets at their galactic coordinates, using the point size and color to show attributes about them. When \"mass\" or \"temperature\" is selected as the size, we'll scale the points down to 0.5% of the corresponding numerical mass or temperature value, so that planets with large masses or high temperatures do not overwhelm the plot. The sizes are thus mainly for relative scale, though a numerical legend could be provided with a bit of work. When plots are colored by a variable, planets for which that variable is not known will be colored grey."
    ]
@@ -391,7 +391,7 @@
    "id": "f7a53376",
    "metadata": {},
    "source": [
-    "Again, we see a dense cluster of candidate exoplanets on the right due to the Kepler spacecraft's area of detection, as well as a curve indicating the Milky Way.\n",
+    "Again, we see a dense cluster of candidate exoplanets on the right due to the Kepler spacecraft's area of detection, as well as a curve indicating ecliptic.\n",
     "\n",
     "Given that all the above plots share the same x and y axes, we can combine them into a single plot so that you can see everything in context:"
    ]
@@ -593,7 +593,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ed18f6b1",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "pn.extension(sizing_mode='stretch_width')\n",
@@ -601,6 +603,8 @@
     "explorer = pn.Row(pn.Column(widgets, overlay, bound_scatter, pn.Row(x_axis, y_axis) ))\n",
     "\n",
     "dashboard = pn.template.BootstrapTemplate(title='Exoplanets Explorer')\n",
+    "dashboard.main.append('Filter, color, and size the displayed exoplanets using the available widgets, and explore trends in the scatterplot below.')\n",
+    "\n",
     "dashboard.main.append(explorer)\n",
     "dashboard.servable()\n",
     "\n",
@@ -617,9 +621,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -7,7 +7,8 @@
    "source": [
     "# Exoplanets\n",
     "Written by Blythe Davis<br>\n",
-    "Created July 23, 2021 (Updated August 7, 2021)"
+    "Created July 23, 2021<br>\n",
+    "Last updated: August 10, 2021"
    ]
   },
   {
@@ -148,7 +149,10 @@
     "def eqtogalL(df):\n",
     "    \"Convert right acension and declination to longitude\"\n",
     "    ret = SkyCoord(ra=float(df.ra)*u.degree,dec=float(df.dec)*u.degree,frame='icrs').galactic\n",
-    "    return float(ret.to_string(\"decimal\").split( )[0])\n",
+    "    l = float(ret.to_string(\"decimal\").split( )[0])\n",
+    "    if l >= 180:\n",
+    "        return l-360\n",
+    "    return l\n",
     "\n",
     "def eqtogalB(df):\n",
     "    \"Convert right acension and declination to latitude\"\n",
@@ -281,7 +285,7 @@
     "\n",
     "To help a user understand the data, we'll allow them to filter it and then plot the results.\n",
     "\n",
-    "To orient users, we'll first create a point representing the Sun. Technically, it should be precisely at the origin $(0,0),$ but only half the circle would be visible on our plot in that case, so we'll move it up to $(10,0)$:"
+    "To orient users, we'll first create a point representing the Sun at the origin $(0,0)$:"
    ]
   },
   {
@@ -291,9 +295,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "origin = pd.DataFrame(data = {'l':[10],'b':[0]})\n",
+    "origin = pd.DataFrame(data = {'l':[0],'b':[0]})\n",
     "\n",
-    "opts  = dict(x=\"b\", y=\"l\", xlabel=\"longitude (deg)\", ylabel=\"latitude (deg)\", responsive=True, aspect=5/2)\n",
+    "opts  = dict(x=\"l\", y=\"b\", xlabel=\"longitude (deg)\", ylabel=\"latitude (deg)\", responsive=True, aspect=5/2)\n",
     "sun = origin.hvplot.scatter(**opts, size=60, color=\"yellow\")\n",
     "#sun"
    ]
@@ -303,7 +307,7 @@
    "id": "7bf33a42",
    "metadata": {},
    "source": [
-    "We could plot that single point by itself, but let's go ahead and overlay it on a background of stars as a frame of reference, using ``rasterize=True`` to use [Datashader](https://datashader.org) to pre-rasterize the data so that it is practical to display in a web browser:"
+    "We could plot that single point by itself, but let's go ahead and overlay it on a background of stars as a frame of reference, setting ``rasterize=True`` to use [Datashader](https://datashader.org) to pre-rasterize the data so that it is practical to display in a web browser:"
    ]
   },
   {
@@ -314,7 +318,7 @@
    "outputs": [],
    "source": [
     "star_background = stars.hvplot.points(\n",
-    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, colorbar=True, **opts).opts(bgcolor=\"black\")\n",
+    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, cnorm='eq_hist', colorbar=True, **opts).opts(bgcolor=\"black\")\n",
     "\n",
     "star_background * sun"
    ]
@@ -324,6 +328,8 @@
    "id": "f2520ec7",
    "metadata": {},
    "source": [
+    "One of the first things that jumps out about this plot is the dark curve separating the two clusters of stars. This dark curve represents our section of the Milky Way.\n",
+    "\n",
     "Now let's plot the planets at their galactic coordinates, using the point size and color to show attributes about them. When \"mass\" or \"temperature\" is selected as the size, we'll scale the points down to 0.5% of the corresponding numerical mass or temperature value, so that planets with large masses or high temperatures do not overwhelm the plot. The sizes are thus mainly for relative scale, though a numerical legend could be provided with a bit of work. When plots are colored by a variable, planets for which that variable is not known will be colored grey."
    ]
   },
@@ -336,7 +342,7 @@
    "source": [
     "def planets(planets=exoplanets, size=\"radius\", color=\"radius\"):\n",
     "    size_scale = 1 if size == \"radius\" else 0.005    \n",
-    "    return planets.hvplot.points(color=color, cmap='blues', size=size_scale*hv.dim(size), clabel=color, **opts)\n",
+    "    return planets.hvplot.points(color=color, cmap='blues', size=size_scale*hv.dim(size), clabel=color, **opts, alpha=0.7)\n",
     "\n",
     "planets()"
    ]
@@ -346,6 +352,8 @@
    "id": "85f403cc",
    "metadata": {},
    "source": [
+    "Two notable features of this graphic are the large, dark blue planet and the dense cluster of smaller planets on the right. The largest planet is the gas giant [HD 100546 b](https://exoplanets.nasa.gov/exoplanet-catalog/6713/hd-100546-b/), with a radius of approximately 77 times that of Earth, and by far the largest exoplanet in our dataset. The clustering behavior on the right is due to the method of detection used in the Kepler mission; the spacecraft pointed at only a small section of the sky, so the detected exoplanets are concentrated in that area.\n",
+    "\n",
     "If we like, we can filter this plot by year and/or by whether it is potentially habitable:"
    ]
   },
@@ -373,7 +381,7 @@
    "id": "195cf044",
    "metadata": {},
    "source": [
-    "We can also filter by whether the planet is potentially escapable with a chemical rocket, which doesn't leave many!"
+    "There aren't a lot of potentially habitable exoplanets, and most of them lie in the cluster detected by Kepler. We can also filter by whether the planet is potentially escapable with a chemical rocket, which leaves even fewer! We'll set their size to 30 so they're more visible."
    ]
   },
   {
@@ -386,7 +394,7 @@
     "def escapable_planets(planets=exoplanets, show=True, color=\"radius\"):\n",
     "    escapable = planets[planets['escapable']==True]\n",
     "    return escapable.hvplot.points(\n",
-    "        cmap='blues', size=12, alpha=0.5, color=\"red\", clabel=color, **opts)\n",
+    "        cmap='blues', size=30, alpha=0.5*int(show), color=\"red\", clabel=color, **opts)\n",
     "    \n",
     "escapable_planets()"
    ]
@@ -396,7 +404,7 @@
    "id": "59d1de75",
    "metadata": {},
    "source": [
-    "Separately, we can look at the candidates exoplanets, e.g. to see how their distribution compares with the confirmed exoplanets:"
+    "Separately, we can look at the candidates exoplanets to see how their distribution compares with the confirmed exoplanets:"
    ]
   },
   {
@@ -420,6 +428,8 @@
    "id": "f7a53376",
    "metadata": {},
    "source": [
+    "Again, we see a dense cluster of candidate exoplanets on the right due to the Kepler spacecraft's area of detection, as well as a curve indicating the Milky Way.\n",
+    "\n",
     "Given that all the above plots share the same x and y axes, we can combine them into a single plot so that you can see everything in context:"
    ]
   },
@@ -438,7 +448,7 @@
    "id": "3584a329",
    "metadata": {},
    "source": [
-    "Whew! That's a bit of a mess. :-) For a user to make much sense of that, we'll need to let them decide what they want to see dynamically; otherwise it's too difficult to see what's what! Later on we'll see how to define some widgets that let them do that. "
+    "Whew, that's a bit of a mess! For a user to make much sense of that, we'll need to let them decide what they want to see dynamically; otherwise it's too difficult to see what's what. Later on we'll see how to define some widgets that let them do that. "
    ]
   },
   {
@@ -459,8 +469,7 @@
    "outputs": [],
    "source": [
     "def scatter(x_axis=\"radius\", y_axis=\"mass\"):\n",
-    "    habitable = exoplanets[exoplanets['habitable']==True].dropna(subset=[x_axis, y_axis])\n",
-    "    uninhabitable = exoplanets[exoplanets['habitable']==False].dropna(subset=[x_axis, y_axis])\n",
+    "    habitable, uninhabitable = exoplanets[exoplanets['habitable']],exoplanets[~exoplanets['habitable']].dropna(subset=[x_axis, y_axis])\n",
     "    habitable_points = habitable.hvplot.scatter(\n",
     "        x=x_axis,y=y_axis, color=\"red\", responsive=True, aspect=5/2,\n",
     "        label=\"Potentially habitable\", size=30, legend='top_right')\n",
@@ -480,7 +489,7 @@
    "source": [
     "In the plot above, we can see that most planets have a mass under 2000 times Earth's and radii under 20 times Earth's, but there are a few outliers. The exoplanet with the largest mass in our dataset is the gas giant [HR 2562-b](https://exoplanets.nasa.gov/exoplanet-catalog/7229/hr-2562-b/), whose mass is over 9000 times Earth's, but whose radius is only about 12 times Earth's.\n",
     "\n",
-    "[GQ Lupi b](https://exoplanets.nasa.gov/exoplanet-catalog/7029/gq-lupi-b/) has the largest radius compared to Earth's, dwarfing our planet by a factor of 33, while its mass is about 6000 times Earth's. On the other side of the scale, the smallest planet in radius is [Kepler-62 c](https://exoplanets.nasa.gov/exoplanet-catalog/373/kepler-62-c/), whose radius is about half of Earth's, but whose mass is quadruple Earth's.\n",
+    "[HD 100546 b](https://exoplanets.nasa.gov/exoplanet-catalog/6713/hd-100546-b/) has the largest radius compared to Earth's, dwarfing our planet by a factor of 77 (that's the big blue planet in the `planets()` plot). On the other side of the scale, the smallest planet in radius is [Kepler-62 c](https://exoplanets.nasa.gov/exoplanet-catalog/373/kepler-62-c/), whose radius is about half of Earth's, but whose mass is quadruple Earth's.\n",
     "\n",
     "The hottest planet in our dataset is the gas giant [KELT-9b](https://exoplanets.nasa.gov/exoplanet-catalog/3508/kelt-9-b/), whose surface temperature is 4050 Kelvin, and the coldest is [OGLE-2005-BLG-390L b](https://exoplanets.nasa.gov/exoplanet-catalog/6081/ogle-2005-blg-390l-b/), at only 50 Kelvin. Temperature and radius appear to have a positive correlation.\n",
     "\n",
@@ -569,7 +578,7 @@
    "id": "0fb43712",
    "metadata": {},
    "source": [
-    "We'll first bind the filtering widgets to the arguments of our filtering function, to generate a dynamically filtered dataframe that will be used in multiple plots:"
+    "We'll first bind the filtering widgets to the arguments of our filtering function to generate a dynamically filtered dataframe that will be used in multiple plots:"
    ]
   },
   {
@@ -587,7 +596,7 @@
    "id": "263f95fe",
    "metadata": {},
    "source": [
-    "Now we can bind this dataframe and the other widgets to the various plotting function arguments. We'll wrap the bound functions as HoloViews DynamicMaps so that we can use the HoloViews `*` overlay operator on them:"
+    "Now we can bind this dataframe and the other widgets to the various plotting function arguments. We'll wrap the bound functions as [HoloViews DynamicMaps](https://holoviews.org/reference/containers/bokeh/DynamicMap.html) so that we can use the HoloViews `*` overlay operator on them:"
    ]
   },
   {
@@ -611,7 +620,7 @@
    "metadata": {},
    "source": [
     "## Putting it all together\n",
-    "Finally, we create a panel from our widgets and plots to display the final dashboard."
+    "Finally, we create a panel from our widgets and plots to display the final dashboard using a [Panel template](https://panel.holoviz.org/user_guide/Templates.html)."
    ]
   },
   {
@@ -621,11 +630,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "text = \"\"\"\n",
-    "# Exoplanets explorer\n",
-    "\"\"\"\n",
+    "pn.extension(sizing_mode='stretch_width')\n",
     "\n",
-    "pn.Row(pn.Column(text, widgets, overlay, bound_scatter, pn.Row(x_axis, y_axis) )).servable()"
+    "explorer = pn.Row(pn.Column(widgets, overlay, bound_scatter, pn.Row(x_axis, y_axis) ))\n",
+    "\n",
+    "dashboard = pn.template.BootstrapTemplate(title='Exoplanets Explorer')\n",
+    "dashboard.main.append(explorer)\n",
+    "dashboard.servable()\n",
+    "\n",
+    "explorer"
    ]
   },
   {
@@ -638,9 +651,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -357,7 +357,7 @@
     "def escapable(planets=exoplanets, size=\"radius\", color=\"radius\"):\n",
     "    escapable = planets[planets['escapable']==True]\n",
     "    return escapable.hvplot.points(\n",
-    "        cmap='blues', size=30, alpha=0.5, color=\"red\", clabel=color, **opts)\n",
+    "        cmap='blues', size=200, alpha=0.5, color=\"purple\", line_width=3, fill_color=None, clabel=color, **opts)\n",
     "    \n",
     "escapable()"
    ]
@@ -403,7 +403,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_bg * planets() * escapable() * unconfirmed() * sun"
+    "star_bg * planets() * unconfirmed() * escapable() * sun"
    ]
   },
   {
@@ -574,8 +574,8 @@
    "source": [
     "overlay = (star_bg * \n",
     "           hv.DynamicMap(pn.bind(planets,     filtered, select_size, select_color)) * \n",
-    "           hv.DynamicMap(pn.bind(escapable,   filtered, select_size, select_color)).apply.opts(visible=show_escapable) * \n",
     "           hv.DynamicMap(pn.bind(unconfirmed, year_range)).apply.opts(visible=show_unconfirmed) *\n",
+    "           hv.DynamicMap(pn.bind(escapable,   filtered, select_size, select_color)).apply.opts(visible=show_escapable) * \n",
     "           sun).opts(title='Map of exoplanets')\n",
     "#overlay"
    ]

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -34,7 +34,8 @@
     "import pandas as pd\n",
     "import holoviews as hv\n",
     "import panel as pn\n",
-    "from colorcet import fire\n",
+    "import numpy as np\n",
+    "import colorcet as cc\n",
     "import hvplot.pandas # noqa\n",
     "\n",
     "hv.extension('bokeh', width=100)"
@@ -127,13 +128,7 @@
    "metadata": {},
    "source": [
     "## Converting coordinates\n",
-    "Because our goal is to generate a map of the exoplanets and stars, we need a standardized coordinate system for all three of our dataframes. Here, we'll use the [Astropy](https://www.astropy.org/) package to perform coordinate transformations. The original datasets use an equatorial coordinate system, given by ``ra`` (right acension) and ``dec`` (declination), but the specific notation varies among the datasets, and equatorial coordinates are less commonly used to visualize space. We will convert to galactic coordinates, a spherical coordinate system centered at the sun. Points in the galactic coordinate system are represented by two values: solar longitude (abbreviated \"l\") and latitude (abbreviated \"b\").\n",
-    "\n",
-    "Using the Astropy ``SkyCoord`` function, we define two functions, ``eqtogalL`` and ``eqtogalB``, which convert equatorial coordinates to galactic coordinates. ``eqtogalL`` takes (``ra``, ``dec``) as an argument and produces the longitude ``l``, while ``eqtogalB`` takes (``ra``, ``dec``) and produces the latitude ``b``.\n",
-    "\n",
-    "If we were to use the entire ``stars`` dataframe, the conversion code would run very slowly. Thus, we consider only the brightest stars (those with the G magnitude, abbreviated `phot_g_mean_mag`, over 11), and of those, we sample 10% using ``.sample(frac=0.1)``.\n",
-    "\n",
-    "After converting, we create new columns in each of our dataframes for latitude and longitude and then cache the results. Note that the size of the datasets means that converting to galactic coordinates can take up to a minute or two. To speed up the process, you can sample a smaller fraction of any of the dataframes."
+    "Because our goal is to generate a map of the exoplanets and stars, we need a standardized coordinate system for all three of our dataframes. Here, we'll use the [Astropy](https://www.astropy.org/) ``SkyCoord`` function to perform coordinate transformations. The original datasets use an equatorial coordinate system, given by ``ra`` (right ascension) and ``dec`` (declination), but the specific notation varies among the datasets, and equatorial coordinates are less commonly used to visualize space. We will convert to galactic coordinates, a spherical coordinate system centered at the sun. Points in the galactic coordinate system are represented by two values: solar longitude (abbreviated \"l\") and latitude (abbreviated \"b\"), so we'll write a function that calculates those values and adds them as columns to the above dataframes:"
    ]
   },
   {
@@ -146,16 +141,12 @@
     "from astropy import units as u\n",
     "from astropy.coordinates import SkyCoord\n",
     "\n",
-    "def eqtogalL(df):\n",
-    "    \"Convert right acension and declination to longitude\"\n",
-    "    ret = SkyCoord(ra=float(df.ra)*u.degree,dec=float(df.dec)*u.degree,frame='icrs').galactic\n",
-    "    l = float(ret.to_string(\"decimal\").split( )[0])\n",
-    "    return l-360 if l >= 180 else l\n",
-    "\n",
-    "def eqtogalB(df):\n",
-    "    \"Convert right acension and declination to latitude\"\n",
-    "    ret = SkyCoord(ra=float(df.ra)*u.degree,dec=float(df.dec)*u.degree,frame='icrs').galactic\n",
-    "    return float(ret.to_string(\"decimal\").split( )[1])"
+    "def eqtogal(df):\n",
+    "    \"Add columns for longitude, latitude calculated from right ascension and declination\"\n",
+    "    ret = SkyCoord(ra=df.ra*u.degree,dec=df.dec*u.degree,frame='icrs').galactic\n",
+    "    l = np.mod(ret.l.degree+180, 360)-180\n",
+    "    b = ret.b.degree\n",
+    "    return df.assign(l=l, b=b)"
    ]
   },
   {
@@ -165,7 +156,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stars = stars[stars[\"phot_g_mean_mag\"]>11].sample(frac=0.1)"
+    "# Limit to the brightest stars, if desired\n",
+    "#stars = stars[stars[\"phot_g_mean_mag\"]>11]"
    ]
   },
   {
@@ -176,34 +168,9 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "stars['l'] = pn.state.as_cached('stars_l', lambda: stars.apply(eqtogalL, axis=1))\n",
-    "stars['b'] = pn.state.as_cached('stars_b', lambda: stars.apply(eqtogalB, axis=1))\n",
-    "stars.reset_index(inplace=True, drop=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4539cd27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "exoplanets['l'] = pn.state.as_cached('exoplanets_l', lambda: exoplanets.apply(eqtogalL, axis=1))\n",
-    "exoplanets['b'] = pn.state.as_cached('exoplanets_b', lambda: exoplanets.apply(eqtogalB, axis=1))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8cd67381",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "candidates['l'] = pn.state.as_cached('candidates_l', lambda: candidates.apply(eqtogalL, axis=1))\n",
-    "candidates['b'] = pn.state.as_cached('candidates_b', lambda: candidates.apply(eqtogalB, axis=1))\n",
-    "candidates.reset_index(inplace=True, drop=True)"
+    "stars      = pn.state.as_cached('stars_lb',      lambda: eqtogal(stars))\n",
+    "exoplanets = pn.state.as_cached('exoplanets_lb', lambda: eqtogal(exoplanets))\n",
+    "candidates = pn.state.as_cached('candidates_lb', lambda: eqtogal(candidates))"
    ]
   },
   {
@@ -261,8 +228,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "\n",
     "def deltav(p):\n",
     "    \"\"\"\n",
     "    Given a planet record or planet dataframe, determine whether delta-v is \n",
@@ -316,7 +281,7 @@
    "outputs": [],
    "source": [
     "star_bg = stars.hvplot.points(\n",
-    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, colorbar=True, cnorm='eq_hist', **opts).opts(bgcolor=\"black\")\n",
+    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=cc.fire, colorbar=True, cnorm='eq_hist', **opts).opts(bgcolor=\"black\")\n",
     "\n",
     "star_bg * sun"
    ]

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -317,10 +317,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_background = stars.hvplot.points(\n",
-    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, cnorm='eq_hist', colorbar=True, **opts).opts(bgcolor=\"black\")\n",
+    "stars = stars.hvplot.points(\n",
+    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, colorbar=True, cnorm='eq_hist', **opts).opts(bgcolor=\"black\")\n",
     "\n",
-    "star_background * sun"
+    "stars * sun"
    ]
   },
   {
@@ -391,12 +391,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def escapable_planets(planets=exoplanets, show=True, color=\"radius\"):\n",
+    "def escapable(planets=exoplanets, size=\"radius\", color=\"radius\"):\n",
     "    escapable = planets[planets['escapable']==True]\n",
     "    return escapable.hvplot.points(\n",
     "        cmap='blues', size=30, alpha=0.5*int(show), color=\"red\", clabel=color, **opts)\n",
     "    \n",
-    "escapable_planets()"
+    "escapable()"
    ]
   },
   {
@@ -404,7 +404,7 @@
    "id": "59d1de75",
    "metadata": {},
    "source": [
-    "Separately, we can look at the candidates exoplanets to see how their distribution compares with the confirmed exoplanets:"
+    "Separately, we can look at the candidate exoplanets to see how their distribution compares with the confirmed exoplanets:"
    ]
   },
   {
@@ -414,13 +414,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def candidate_exoplanets(year_range=(-np.inf,np.inf), show=True):\n",
+    "def unconfirmed(year_range=(-np.inf,np.inf)):\n",
     "    \"Filter candidate exoplanets by year range and plot them in b,l space\"\n",
     "    c = candidates\n",
     "    filtered_candidates = c[(c.year>=year_range[0]) & (c.year<=year_range[1])]\n",
-    "    return filtered_candidates.hvplot.points(size=30, color=\"green\", alpha=0.5*int(show), **opts)\n",
+    "    return filtered_candidates.hvplot.points(size=30, color=\"green\", alpha=0.5, **opts)\n",
     "\n",
-    "candidate_exoplanets()"
+    "unconfirmed()"
    ]
   },
   {
@@ -440,7 +440,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_background * planets() * escapable_planets() * sun * candidate_exoplanets(show=False)"
+    "stars * planets() * escapable() * unconfirmed() * sun"
    ]
   },
   {
@@ -469,14 +469,18 @@
    "outputs": [],
    "source": [
     "def scatter(x_axis=\"radius\", y_axis=\"mass\"):\n",
-    "    habitable, uninhabitable = exoplanets[exoplanets['habitable']],exoplanets[~exoplanets['habitable']].dropna(subset=[x_axis, y_axis])\n",
+    "    habitable     = exoplanets[exoplanets['habitable']==True ].dropna(subset=[x_axis, y_axis])\n",
+    "    uninhabitable = exoplanets[exoplanets['habitable']==False].dropna(subset=[x_axis, y_axis])\n",
+    "    \n",
     "    habitable_points = habitable.hvplot.scatter(\n",
     "        x=x_axis,y=y_axis, color=\"red\", responsive=True, aspect=5/2,\n",
     "        label=\"Potentially habitable\", size=30, legend='top_right')\n",
+    "    \n",
     "    uninhabitable_points = uninhabitable.hvplot.scatter(\n",
     "        x=x_axis, y=y_axis, responsive=True, aspect=5/2,\n",
     "        color=\"blue\", alpha=0.5, legend='top_right',\n",
     "        label=\"Uninhabitable\", size=10)\n",
+    "    \n",
     "    return uninhabitable_points * habitable_points.opts(title=f'Scatterplot of {x_axis} and {y_axis}')\n",
     "\n",
     "scatter()"
@@ -557,19 +561,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "year_range      = pn.widgets.RangeSlider( name='Discovery year range', start=1996, end=2021)\n",
-    "show_candidates = pn.widgets.Checkbox(    name='Show unconfirmed exoplanets')\n",
-    "show_habitable  = pn.widgets.Checkbox(    name='Show only planets in potentially habitable zone')\n",
-    "show_escapable  = pn.widgets.Checkbox(    name='Show which planets could be escaped with a chemical rocket')\n",
-    "select_size     = pn.widgets.Select(      name='Size points by:',  options=axis_choices)\n",
-    "select_color    = pn.widgets.Select(      name='Color points by:', options=axis_choices)\n",
+    "year_range       = pn.widgets.RangeSlider( name='Discovery year range', start=1996, end=2021)\n",
+    "show_unconfirmed = pn.widgets.Checkbox(    name='Show unconfirmed exoplanets')\n",
+    "show_habitable   = pn.widgets.Checkbox(    name='Limit to potentially habitable planets')\n",
+    "show_escapable   = pn.widgets.Checkbox(    name='Show which planets could be escaped with a chemical rocket')\n",
+    "select_size      = pn.widgets.Select(      name='Size points by:',  options=axis_choices)\n",
+    "select_color     = pn.widgets.Select(      name='Color points by:', options=axis_choices)\n",
     "\n",
     "widgets = pn.Column(\n",
     "    pn.Row(\n",
     "        pn.Column(select_size, select_color),\n",
-    "        pn.Column(year_range, show_candidates, show_escapable, show_habitable)\n",
-    "    )\n",
-    ")\n",
+    "        pn.Column(year_range, show_unconfirmed, show_escapable, show_habitable)))\n",
+    "\n",
     "#widgets"
    ]
   },
@@ -606,10 +609,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overlay = (star_background * \n",
-    "           hv.DynamicMap(pn.bind(planets,              filtered,   select_size,    select_color)) * \n",
-    "           hv.DynamicMap(pn.bind(escapable_planets,    filtered,   show_escapable, select_color)) * \n",
-    "           hv.DynamicMap(pn.bind(candidate_exoplanets, year_range, show_candidates)) *\n",
+    "overlay = (stars * \n",
+    "           hv.DynamicMap(pn.bind(planets,     filtered, select_size, select_color)) * \n",
+    "           hv.DynamicMap(pn.bind(escapable,   filtered, select_size, select_color)).apply.opts(visible=show_escapable) * \n",
+    "           hv.DynamicMap(pn.bind(unconfirmed, year_range)).apply.opts(visible=show_unconfirmed) *\n",
     "           sun).opts(title='Map of exoplanets')\n",
     "#overlay"
    ]

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -36,8 +36,7 @@
     "from colorcet import fire\n",
     "import hvplot.pandas # noqa\n",
     "\n",
-    "pn.extension()\n",
-    "hv.extension('bokeh',width=100)"
+    "hv.extension('bokeh', width=100)"
    ]
   },
   {
@@ -304,7 +303,7 @@
    "id": "7bf33a42",
    "metadata": {},
    "source": [
-    "We could plot that single point by itself, but let's go ahead and overlay it on a background of stars as a frame of reference, using ``datashade=True`` to use [Datashader](https://datashader.org) to pre-rasterize the data so that it is practical to display in a web browser:"
+    "We could plot that single point by itself, but let's go ahead and overlay it on a background of stars as a frame of reference, using ``rasterize=True`` to use [Datashader](https://datashader.org) to pre-rasterize the data so that it is practical to display in a web browser:"
    ]
   },
   {
@@ -314,9 +313,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_background = (stars.hvplot.points(**opts,datashade=True,\n",
-    "                                       color=\"phot_g_mean_mag\",cmap=fire,\n",
-    "                                       colorbar=True)).opts(bgcolor=\"black\")\n",
+    "star_background = stars.hvplot.points(\n",
+    "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, colorbar=True, **opts).opts(bgcolor=\"black\")\n",
+    "\n",
     "star_background * sun"
    ]
   },
@@ -336,9 +335,8 @@
    "outputs": [],
    "source": [
     "def planets(planets=exoplanets, size=\"radius\", color=\"radius\"):\n",
-    "    size_scale = 1 if size == \"radius\" else 0.005\n",
-    "    points = planets.hvplot.points(**opts, color=color, size=size, clabel=color)\n",
-    "    return points.opts(cmap='blues', size=size_scale*hv.dim(size))\n",
+    "    size_scale = 1 if size == \"radius\" else 0.005    \n",
+    "    return planets.hvplot.points(color=color, cmap='blues', size=size_scale*hv.dim(size), clabel=color, **opts)\n",
     "\n",
     "planets()"
    ]
@@ -358,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def habitable_exoplanets_by_year(year_range=(-np.inf,np.inf), hab=False):\n",
+    "def habitable_exoplanets_by_year(year_range=(-np.inf, np.inf), hab=False):\n",
     "    \"Exoplanets filtered by the given year range and (if hab=True) whether they are habitable\"\n",
     "    e = exoplanets\n",
     "    filtered = e[(e.disc_year>=year_range[0]) & (e.disc_year<=year_range[1])]\n",
@@ -367,7 +365,7 @@
     "    filtered = filtered.drop_duplicates()\n",
     "    return filtered\n",
     "\n",
-    "planets(habitable_exoplanets_by_year((1996,2021), True))"
+    "planets(habitable_exoplanets_by_year((1996, 2021), True))"
    ]
   },
   {
@@ -387,9 +385,9 @@
    "source": [
     "def escapable_planets(planets=exoplanets, show=True, color=\"radius\"):\n",
     "    escapable = planets[planets['escapable']==True]\n",
-    "    escapable_points = escapable.hvplot.points(**opts, color=\"red\", clabel=color)\n",
-    "    return escapable_points.opts(cmap='blues', size=12, alpha=0.5)\n",
-    "\n",
+    "    return escapable.hvplot.points(\n",
+    "        cmap='blues', size=12, alpha=0.5, color=\"red\", clabel=color, **opts)\n",
+    "    \n",
     "escapable_planets()"
    ]
   },
@@ -410,9 +408,9 @@
    "source": [
     "def candidate_exoplanets(year_range=(-np.inf,np.inf), show=True):\n",
     "    \"Filter candidate exoplanets by year range and plot them in b,l space\"\n",
-    "    c=candidates\n",
+    "    c = candidates\n",
     "    filtered_candidates = c[(c.year>=year_range[0]) & (c.year<=year_range[1])]\n",
-    "    return filtered_candidates.hvplot.points(**opts, size=30, color=\"green\", alpha=0.5*int(show))\n",
+    "    return filtered_candidates.hvplot.points(size=30, color=\"green\", alpha=0.5*int(show), **opts)\n",
     "\n",
     "candidate_exoplanets()"
    ]
@@ -463,12 +461,14 @@
     "def scatter(x_axis=\"radius\", y_axis=\"mass\"):\n",
     "    habitable = exoplanets[exoplanets['habitable']==True].dropna(subset=[x_axis, y_axis])\n",
     "    uninhabitable = exoplanets[exoplanets['habitable']==False].dropna(subset=[x_axis, y_axis])\n",
-    "    habitable_points = habitable.hvplot.scatter(x=x_axis,y=y_axis,color=\"red\", responsive=True, aspect=5/2,\n",
-    "                                                label=\"Potentially habitable\",size=30).opts(legend_position='top_right')\n",
-    "    uninhabitable_points = uninhabitable.hvplot.scatter(x=x_axis,y=y_axis, responsive=True, aspect=5/2,\n",
-    "                                                        color=\"blue\",alpha=0.5,\n",
-    "                                                        label=\"Uninhabitable\",size=10).opts(legend_position='top_right')\n",
-    "    return uninhabitable_points*habitable_points.opts(title=f'Scatterplot of {x_axis} and {y_axis}')\n",
+    "    habitable_points = habitable.hvplot.scatter(\n",
+    "        x=x_axis,y=y_axis, color=\"red\", responsive=True, aspect=5/2,\n",
+    "        label=\"Potentially habitable\", size=30, legend='top_right')\n",
+    "    uninhabitable_points = uninhabitable.hvplot.scatter(\n",
+    "        x=x_axis, y=y_axis, responsive=True, aspect=5/2,\n",
+    "        color=\"blue\", alpha=0.5, legend='top_right',\n",
+    "        label=\"Uninhabitable\", size=10)\n",
+    "    return uninhabitable_points * habitable_points.opts(title=f'Scatterplot of {x_axis} and {y_axis}')\n",
     "\n",
     "scatter()"
    ]
@@ -507,7 +507,7 @@
    "outputs": [],
    "source": [
     "pn.config.sizing_mode=\"stretch_width\"\n",
-    "axis_choices={\"Earth radius\":\"radius\", \"Earth mass\":\"mass\", \"Temperature\": \"temperature\"}\n",
+    "axis_choices={\"Earth radius\": \"radius\", \"Earth mass\": \"mass\", \"Temperature\": \"temperature\"}\n",
     "\n",
     "x_axis = pn.widgets.Select(name='x-axis:', options=axis_choices)\n",
     "y_axis = pn.widgets.Select(name='y-axis:', options=axis_choices, value='mass')"
@@ -555,8 +555,12 @@
     "select_size     = pn.widgets.Select(      name='Size points by:',  options=axis_choices)\n",
     "select_color    = pn.widgets.Select(      name='Color points by:', options=axis_choices)\n",
     "\n",
-    "widgets = pn.Column(pn.Row(pn.Column(select_size, select_color),\n",
-    "                    pn.Column(year_range, show_candidates, show_escapable, show_habitable)))\n",
+    "widgets = pn.Column(\n",
+    "    pn.Row(\n",
+    "        pn.Column(select_size, select_color),\n",
+    "        pn.Column(year_range, show_candidates, show_escapable, show_habitable)\n",
+    "    )\n",
+    ")\n",
     "#widgets"
    ]
   },

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -150,9 +150,7 @@
     "    \"Convert right acension and declination to longitude\"\n",
     "    ret = SkyCoord(ra=float(df.ra)*u.degree,dec=float(df.dec)*u.degree,frame='icrs').galactic\n",
     "    l = float(ret.to_string(\"decimal\").split( )[0])\n",
-    "    if l >= 180:\n",
-    "        return l-360\n",
-    "    return l\n",
+    "    return l-360 if l >= 180 else l\n",
     "\n",
     "def eqtogalB(df):\n",
     "    \"Convert right acension and declination to latitude\"\n",
@@ -298,7 +296,7 @@
     "origin = pd.DataFrame(data = {'l':[0],'b':[0]})\n",
     "\n",
     "opts  = dict(x=\"l\", y=\"b\", xlabel=\"longitude (deg)\", ylabel=\"latitude (deg)\", responsive=True, aspect=5/2)\n",
-    "sun = origin.hvplot.scatter(**opts, size=60, color=\"yellow\")\n",
+    "sun = origin.hvplot.scatter(**opts, size=80, color=\"yellow\")\n",
     "#sun"
    ]
   },
@@ -317,10 +315,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stars = stars.hvplot.points(\n",
+    "star_bg = stars.hvplot.points(\n",
     "    rasterize=True, color=\"phot_g_mean_mag\", cmap=fire, colorbar=True, cnorm='eq_hist', **opts).opts(bgcolor=\"black\")\n",
     "\n",
-    "stars * sun"
+    "star_bg * sun"
    ]
   },
   {
@@ -394,7 +392,7 @@
     "def escapable(planets=exoplanets, size=\"radius\", color=\"radius\"):\n",
     "    escapable = planets[planets['escapable']==True]\n",
     "    return escapable.hvplot.points(\n",
-    "        cmap='blues', size=30, alpha=0.5*int(show), color=\"red\", clabel=color, **opts)\n",
+    "        cmap='blues', size=30, alpha=0.5, color=\"red\", clabel=color, **opts)\n",
     "    \n",
     "escapable()"
    ]
@@ -440,7 +438,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stars * planets() * escapable() * unconfirmed() * sun"
+    "star_bg * planets() * escapable() * unconfirmed() * sun"
    ]
   },
   {
@@ -609,7 +607,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overlay = (stars * \n",
+    "overlay = (star_bg * \n",
     "           hv.DynamicMap(pn.bind(planets,     filtered, select_size, select_color)) * \n",
     "           hv.DynamicMap(pn.bind(escapable,   filtered, select_size, select_color)).apply.opts(visible=show_escapable) * \n",
     "           hv.DynamicMap(pn.bind(unconfirmed, year_range)).apply.opts(visible=show_unconfirmed) *\n",
@@ -654,22 +652,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/exoplanets/exoplanets.ipynb
+++ b/exoplanets/exoplanets.ipynb
@@ -7,8 +7,7 @@
    "source": [
     "# Exoplanets\n",
     "Written by Blythe Davis<br>\n",
-    "Created: July 23, 2021\n",
-    "Updated: July 23, 2021"
+    "Created July 23, 2021 (Updated August 7, 2021)"
    ]
   },
   {
@@ -17,7 +16,11 @@
    "metadata": {},
    "source": [
     "## Exoplanet Discovery\n",
-    "For the past 25+ years, NASA has used ground- and space-based methods to [identify exoplanets](https://exoplanets.nasa.gov/exep/about/missions-instruments) (planets outside of our solar system). In the past ten years in particular, campaigns like Kepler, K2, and TESS have produced an explosion of results. To date, approximately 4,400 exoplanets have been identified, and over 3,000 potential exoplanet candidates have been discovered. In this notebook, we will use Holoviews and Panel together with Astropy to make a dashboard visualizing the discovery of confirmed and candidate exoplanets over the years. We'll also include a scatterplot in our dashboard that reveals details about the relationship between mass and radius of exoplanets, as well as controls to filter the data based on whether the planets could support life, and if so, if chemical rockets could be used to escape the planet."
+    "For the past 25+ years, NASA has used ground- and space-based methods to [identify exoplanets](https://exoplanets.nasa.gov/exep/about/missions-instruments) (planets outside of our solar system). In the past ten years in particular, campaigns like Kepler, K2, and TESS have produced an explosion of results. To date, approximately 4,400 exoplanets have been identified, and over 3,000 potential exoplanet candidates have been discovered. \n",
+    "\n",
+    "In this notebook, we will use [Holoviews](https://holoviews.holoviz.org) and [Panel](https://panel.holoviz.org) together with [Astropy](https://www.astropy.org) to make a dashboard visualizing the discovery of confirmed and candidate exoplanets over the years. \n",
+    "\n",
+    "We'll also include a scatterplot in our dashboard that reveals details about the relationship between mass and radius of exoplanets, as well as controls to filter the data based on whether the planets could support life, and if so, whether chemical rockets could be used to escape the planet."
    ]
   },
   {
@@ -43,7 +46,33 @@
    "metadata": {},
    "source": [
     "## Loading data\n",
-    "For this notebook, we will be loading our exoplanet data from three different CSV files: [stars](data/stars.csv), a [dataset of 257,000 stars](https://www.kaggle.com/solorzano/257k-gaia-dr2-stars?select=257k-gaiadr2-sources-with-photometry.csv) identified by the European Gaia space mission; [exoplanets](data/exoplanets.csv), a collection of 480 exoplanets obtained from the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu/); and [candidates](data/candidates.csv), a collection of approximately 3,000 candidate exoplanets collated from the [Kepler](http://exoplanets.org/table?datasets=kepler) and [TESS](https://exofop.ipac.caltech.edu/tess/view_toi.php) campaigns. Since these datasets are fairly large, we'll cache the data using Panel:"
+    "For this notebook, we will be loading our exoplanet data from three different CSV files: \n",
+    "- [stars](data/stars.csv), a [dataset of 257,000 stars](https://www.kaggle.com/solorzano/257k-gaia-dr2-stars?select=257k-gaiadr2-sources-with-photometry.csv) identified by the European Gaia space mission,\n",
+    "- [exoplanets](data/exoplanets.csv), a collection of 480 exoplanets obtained from the [NASA Exoplanet Archive](https://exoplanetarchive.ipac.caltech.edu/); and \n",
+    "- [candidates](data/candidates.csv), a collection of approximately 3,000 candidate exoplanets collated from the [Kepler](http://exoplanets.org/table?datasets=kepler) and [TESS](https://exofop.ipac.caltech.edu/tess/view_toi.php) campaigns. \n",
+    "\n",
+    "We could load the data using pure Pandas calls like `stars = pd.read_csv(\"data/stars.csv\")`, but here let's cache the results using Panel so that new visitors to the dashboard won't have to reload or recalculate the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f08f1bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "stars      = pn.state.as_cached('stars',      lambda: pd.read_csv(\"data/stars.csv\"))\n",
+    "exoplanets = pn.state.as_cached('exoplanets', lambda: pd.read_csv(\"data/exoplanets.csv\"))\n",
+    "candidates = pn.state.as_cached('candidates', lambda: pd.read_csv(\"data/candidates.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5b68d63",
+   "metadata": {},
+   "source": [
+    "The stars data includes the coordinates and brightness of the star:"
    ]
   },
   {
@@ -53,8 +82,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stars = pn.state.as_cached('stars', lambda: pd.read_csv(\"data/stars.csv\"))\n",
     "stars.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7b0eb1d",
+   "metadata": {},
+   "source": [
+    "The exoplanets data includes the coordinates along with a variety of attributes about the planet:"
    ]
   },
   {
@@ -64,8 +100,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exoplanets = pn.state.as_cached('exoplanets', lambda: pd.read_csv(\"data/exoplanets.csv\"))\n",
     "exoplanets.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ed40c94",
+   "metadata": {},
+   "source": [
+    "Candidate data is sparse and includes only a few attributes besides the coordinates:"
    ]
   },
   {
@@ -75,7 +118,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "candidates = pn.state.as_cached('candidates', lambda: pd.read_csv(\"data/candidates.csv\"))\n",
     "candidates.head()"
    ]
   },
@@ -85,13 +127,13 @@
    "metadata": {},
    "source": [
     "## Converting coordinates\n",
-    "Because our goal is to generate a map of the exoplanets and stars, we need a standardized coordinate system for all three of our dataframes. Here, we'll use the [Astropy](https://www.astropy.org/) package to perform coordinate transformations. The original datasets use an equatorial coordinate system, given by ``ra`` (right acension) and ``dec`` (declination), but the specific notation varies among the datasets, and equatorial coordinates are less commonly used to visualize space. We will convert to galactic coordinates, a spherical coordinate system centered at the sun. Points in the galactic coordinate system are represented by two values: longitude (abbreviated \"l\") and latitude (abbreviated \"b\").\n",
+    "Because our goal is to generate a map of the exoplanets and stars, we need a standardized coordinate system for all three of our dataframes. Here, we'll use the [Astropy](https://www.astropy.org/) package to perform coordinate transformations. The original datasets use an equatorial coordinate system, given by ``ra`` (right acension) and ``dec`` (declination), but the specific notation varies among the datasets, and equatorial coordinates are less commonly used to visualize space. We will convert to galactic coordinates, a spherical coordinate system centered at the sun. Points in the galactic coordinate system are represented by two values: solar longitude (abbreviated \"l\") and latitude (abbreviated \"b\").\n",
     "\n",
     "Using the Astropy ``SkyCoord`` function, we define two functions, ``eqtogalL`` and ``eqtogalB``, which convert equatorial coordinates to galactic coordinates. ``eqtogalL`` takes (``ra``, ``dec``) as an argument and produces the longitude ``l``, while ``eqtogalB`` takes (``ra``, ``dec``) and produces the latitude ``b``.\n",
     "\n",
-    "If we were to use the entire ``stars`` dataframe, this program would run very slowly. Thus, we consider only the brightest stars (those with the G magnitude, abbreviated \"phot_g_mean_mag,\" over 11), and of those, we sample 10% using ``.sample(frac=0.1)``.\n",
+    "If we were to use the entire ``stars`` dataframe, the conversion code would run very slowly. Thus, we consider only the brightest stars (those with the G magnitude, abbreviated `phot_g_mean_mag`, over 11), and of those, we sample 10% using ``.sample(frac=0.1)``.\n",
     "\n",
-    "After converting, we create new columns in each of our dataframes for latitude and longitude then cache the results. Note that the size of the datasets means that converting to galactic coordinates can take up to a minute or two. To speed up the process, you can sample a fraction of any of the dataframes."
+    "After converting, we create new columns in each of our dataframes for latitude and longitude and then cache the results. Note that the size of the datasets means that converting to galactic coordinates can take up to a minute or two. To speed up the process, you can sample a smaller fraction of any of the dataframes."
    ]
   },
   {
@@ -128,39 +170,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5b6a6ef",
+   "id": "07c28de4",
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "stars['l'] = pn.state.as_cached('stars_l', lambda: stars.apply(eqtogalL, axis=1))\n",
     "stars['b'] = pn.state.as_cached('stars_b', lambda: stars.apply(eqtogalB, axis=1))\n",
-    "stars.reset_index(inplace=True, drop=True)\n",
-    "stars.head()"
+    "stars.reset_index(inplace=True, drop=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a513699",
+   "id": "4539cd27",
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "exoplanets['l'] = pn.state.as_cached('exoplanets_l', lambda: exoplanets.apply(eqtogalL, axis=1))\n",
-    "exoplanets['b'] = pn.state.as_cached('exoplanets_b', lambda: exoplanets.apply(eqtogalB, axis=1))\n",
-    "exoplanets.head()"
+    "exoplanets['b'] = pn.state.as_cached('exoplanets_b', lambda: exoplanets.apply(eqtogalB, axis=1))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c20a12c",
+   "id": "8cd67381",
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "candidates['l'] = pn.state.as_cached('candidates_l', lambda: candidates.apply(eqtogalL, axis=1))\n",
     "candidates['b'] = pn.state.as_cached('candidates_b', lambda: candidates.apply(eqtogalB, axis=1))\n",
-    "candidates.reset_index(inplace=True, drop=True)\n",
-    "candidates.head()"
+    "candidates.reset_index(inplace=True, drop=True)"
    ]
   },
   {
@@ -169,7 +211,7 @@
    "metadata": {},
    "source": [
     "## The Goldilocks zone and the Tsiolkovsky rocket equation\n",
-    "One of the methods used to determine which exoplanets could potentially support life is to check whether liquid water could exist there. For water to be present on the planet as liquid, the planet's temperature must be within a fairly narrow range, and therefore the planet must be within a certain distance of the nearest star. Exoplanets within this range are said to be in the \"Goldilocks zone.\"\n",
+    "One of the methods used to determine whether an exoplanet could potentially support life is to check whether liquid water could exist there. For water to be present on the planet as liquid, the planet's temperature must be within a fairly narrow range, and therefore the planet must be within a certain distance of the nearest star. Exoplanets within this range are said to be in the \"Goldilocks zone.\"\n",
     "\n",
     "If intelligent life were to exist on one of these planets, would it be capable of space travel? If the hypothetical life forms used similar methods to humans — for example, hydrogen- and oxygen-powered chemical rockets — would they even be able to leave their planet? A heavier rocket requires exponentially more fuel, but more fuel means more mass. The Tsiolkovsky rocket equation makes this question more precise:\n",
     "\n",
@@ -178,7 +220,7 @@
     "where $\\Delta v$ is the [impulse per mass unit](https://en.wikipedia.org/wiki/Impulse_(physics)) required for the rocket to travel its course, $v_e$ is [effective exhaust velocity](https://en.wikipedia.org/wiki/Specific_impulse#Specific_impulse_as_effective_exhaust_velocity), $m_0$ is the initial mass of the rocket, and $m_f$ is the final mass of the rocket (here, equal to $m_0$ minus the mass of the fuel spent on the flight). To see the rocket equation in action, consider a planet of the same density as Earth with radius $R$ double Earth's and thus mass $M$ eight times Earth's. \n",
     "<p></p>\n",
     "\n",
-    "<details><summary>Computation details</summary>\n",
+    "<details><summary><i><u>(Click to expand/contract computation details)</u></i></summary>\n",
     "    \n",
     "For the purposes of this example, we'll assume that $$\\Delta v = \\sqrt{\\frac{GM}{R}},$$ where $G\\approx 6.67\\cdot 10^{-11}$ (in reality, some complicating factors exist, but our formula works as an approximation at relatively low altitudes$^*$). Then\n",
     "\n",
@@ -194,8 +236,7 @@
     "\n",
     "$^*$We won't go into detail here, but the $\\Delta v$ calulation for $250$ m is derived from the [vis-viva equation](https://en.wikipedia.org/wiki/Vis-viva_equation).</details>\n",
     "\n",
-    "To make it to $250$ m above this planet's surface, about $98.5\\%$ of the rocket's initial mass would need to be fuel. For comparison, the rocket with the highest initial-to-final mass ratio ever built was the [Soyuz-FG](https://en.wikipedia.org/wiki/Soyuz-FG) rocket, which was $91\\%$ fuel by mass. Moreover, we were very generous with the conditions used to compute the mass ratio to escape our imaginary planet. The exhaust velocity we used was only ever recorded for a highly corrosive, dangerous, expensive propellant that, with the current state of technology, is not feasible for use in space travel.\n",
-    "\n"
+    "To make it to $250$ m above this planet's surface, about $98.5\\%$ of the rocket's initial mass would need to be fuel. For comparison, the rocket with the highest initial-to-final mass ratio ever built was the [Soyuz-FG](https://en.wikipedia.org/wiki/Soyuz-FG) rocket, which was $91\\%$ fuel by mass. Moreover, we were very generous with the conditions used to compute the mass ratio to escape our imaginary planet. The exhaust velocity we used was only ever recorded for a highly corrosive, dangerous, expensive propellant that, with the current state of technology, is not feasible for use in space travel."
    ]
   },
   {
@@ -205,7 +246,7 @@
    "source": [
     "## Filtering by feasibility of space travel\n",
     "\n",
-    "We can use the rocket equation to get an idea of which exoplanets might be the right size to allow for space travel. Let's assume that the hypothetical life forms on an exoplanet can make a chemical rocket with exhaust velocity at most $5320\\frac{\\text{m}}{\\text{s}}.$ Let's also say that they've figured out how to make rockets that are up to $95\\%$ fuel by mass (so $\\frac{m_0}{m_f}=20$). These two assumptions will allow us to make an educated guess of whether the mass and radius of the exoplanet would allow for space travel with these rockets:\n",
+    "We can use the rocket equation to get an idea which exoplanets might be the right size to allow for space travel. Let's assume that the hypothetical life forms on an exoplanet can make a chemical rocket with exhaust velocity at most $5320\\frac{\\text{m}}{\\text{s}}.$ Let's also say that they've figured out how to make rockets that are up to $95\\%$ fuel by mass (so $\\frac{m_0}{m_f}=20$). These two (generous) assumptions will allow us to make an educated guess of whether the mass and radius of the exoplanet would ever conceivably allow for space travel:\n",
     "\n",
     "$$\\sqrt{\\frac{GM}{R}}\\approx \\Delta v \\leq 5320\\ln{20}.$$\n",
     "\n",
@@ -215,60 +256,33 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fe0b819",
+   "id": "ce46ed05",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import math\n",
+    "import numpy as np\n",
     "\n",
-    "def deltav(exoplanets):\n",
-    "    m = exoplanets.mass\n",
-    "    r = exoplanets.radius\n",
-    "    h = exoplanets.habitable\n",
-    "    \"Determine whether delta-v is sufficiently small for feasible space travel with chemical rockets\"\n",
+    "def deltav(p):\n",
+    "    \"\"\"\n",
+    "    Given a planet record or planet dataframe, determine whether delta-v is \n",
+    "    sufficiently small for feasible space travel with chemical rockets\n",
+    "    \"\"\"\n",
     "    G = 6.67*(10**(-11))\n",
-    "    if math.sqrt(G*m/r)<=5320*math.log(20) and h == True:\n",
-    "        return True\n",
-    "    else:\n",
-    "        return False\n",
-    "exoplanets['escapable'] = pn.state.as_cached('escapable', lambda: exoplanets.apply(deltav, axis=1))\n",
-    "exoplanets.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "735be04e",
-   "metadata": {},
-   "source": [
-    "## Defining widgets\n",
+    "    return np.logical_and(p.habitable, np.sqrt(G*p.mass/p.radius)<=5320*np.log(20))\n",
     "\n",
-    "We will use Panel to define widgets for our dashboard: a slider representing discovery year, a checkbox determining whether to show unconfirmed exoplanets, a second checkbox determining whether to display only planets in the potentially habitable zone, and two dropdown menus to determine what the size and color of the points on the plot will represent."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f795fb58",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "year_range = pn.widgets.RangeSlider(name='Discovery year range', start=1996, end=2021)\n",
-    "checkbox_candidates = pn.widgets.Checkbox(name='Show uncomfirmed exoplanets')\n",
-    "checkbox_habitable = pn.widgets.Checkbox(name='Show only planets in potentially habitable zone')\n",
-    "checkbox_escapable = pn.widgets.Checkbox(name='Mark planets in habitable zone that could be escaped with a chemical rocket')\n",
-    "select_size = pn.widgets.Select(name='Size points by:', options={\"Earth radius\":\"radius\", \"Earth mass\":\"mass\",\n",
-    "                                                                 \"Temperature\": \"temperature\"})\n",
-    "select_color = pn.widgets.Select(name='Color points by:', options={\"Earth radius\":\"radius\", \"Earth mass\":\"mass\",\n",
-    "                                                                   \"Temperature\": \"temperature\"})\n",
-    "widgets = [year_range, checkbox_candidates, checkbox_habitable, checkbox_escapable, select_size, select_color]"
+    "exoplanets['escapable'] = pn.state.as_cached('escapable', lambda: deltav(exoplanets))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3e9a4f1d",
+   "id": "dcd69e47",
    "metadata": {},
    "source": [
-    "We'll also create a point representing the sun to orient users. Technically, it should be right at the origin, $(0,0),$ but only half the circle would be visible on our plot in that case, so we'll move it up to $(10,0).$"
+    "## Filtering and plotting data\n",
+    "\n",
+    "To help a user understand the data, we'll allow them to filter it and then plot the results.\n",
+    "\n",
+    "To orient users, we'll first create a point representing the Sun. Technically, it should be precisely at the origin $(0,0),$ but only half the circle would be visible on our plot in that case, so we'll move it up to $(10,0)$:"
    ]
   },
   {
@@ -278,81 +292,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "d = {'l':[10],'b':[0]}\n",
-    "origin = pd.DataFrame(data=d)"
+    "origin = pd.DataFrame(data = {'l':[10],'b':[0]})\n",
+    "\n",
+    "opts  = dict(x=\"b\", y=\"l\", xlabel=\"longitude (deg)\", ylabel=\"latitude (deg)\", responsive=True, aspect=5/2)\n",
+    "sun = origin.hvplot.scatter(**opts, size=60, color=\"yellow\")\n",
+    "#sun"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "36b877fe",
+   "id": "7bf33a42",
    "metadata": {},
    "source": [
-    "## Filtering and plotting points\n",
-    "To generate our plot, we'll need a function ``gal_map`` that takes the values of our widgets as input, uses them to filter the data, and outputs a plot of the relative positions of the exoplanets (and candidates, depending on whether the corresponding checkbox is selected) with the data points from ``stars`` as the background and a yellow point ``sun`` at (0,0) representing the sun. To simplify, we will also define ``filter_year``, ``filter_candidates``, ``filter_habitable``, and ``show_escapable`` to filter the data. For ``stars``, we'll include ``datashade=True`` to use [Datashader](https://datashader.org/), which helps more accurately visualize large datasets like the ``stars`` dataframe.\n",
-    "\n",
-    "Note that when \"mass\" or \"temperature\" is selected to deterimine the size of the points, we scale the points to 1% of the actual value using ``size_scale``; this way, planets with large masses or high temperatures do not overwhelm the plot but the relative sizes of the points retain their meaning. Also, since complete data are not available for all planets, those missing the selected variable will be colored grey."
+    "We could plot that single point by itself, but let's go ahead and overlay it on a background of stars as a frame of reference, using ``datashade=True`` to use [Datashader](https://datashader.org) to pre-rasterize the data so that it is practical to display in a web browser:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99df191e",
+   "id": "d1f5cc2c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "def filter_year(e, year_range):\n",
-    "    exo_lower = e.disc_year>=year_range[0]\n",
-    "    exo_upper = e.disc_year<=year_range[1]\n",
-    "    exo_filter = exo_lower & exo_upper\n",
-    "    return e[exo_filter].drop_duplicates()"
+    "star_background = (stars.hvplot.points(**opts,datashade=True,\n",
+    "                                       color=\"phot_g_mean_mag\",cmap=fire,\n",
+    "                                       colorbar=True)).opts(bgcolor=\"black\")\n",
+    "star_background * sun"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c3c4a7f2",
+   "cell_type": "markdown",
+   "id": "f2520ec7",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "def filter_candidates(c, year_range):\n",
-    "    can_lower = c.year>=year_range[0]\n",
-    "    can_upper = c.year<=year_range[1]\n",
-    "    can_mask = can_lower & can_upper\n",
-    "    return c[can_mask]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1360f988",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def filter_habitable(e):\n",
-    "    hab = e.habitable == True\n",
-    "    exo_filter = hab\n",
-    "    return e[exo_filter].drop_duplicates()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f87106ae",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def show_escapable(e):\n",
-    "    return e[e['escapable']==True]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c911a2ca",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "opts = {\"x\":\"b\",\"y\":\"l\",\"xlabel\":\"longitude (deg)\",\"ylabel\":\"latitude (deg)\"}"
+    "Now let's plot the planets at their galactic coordinates, using the point size and color to show attributes about them. When \"mass\" or \"temperature\" is selected as the size, we'll scale the points down to 0.5% of the corresponding numerical mass or temperature value, so that planets with large masses or high temperatures do not overwhelm the plot. The sizes are thus mainly for relative scale, though a numerical legend could be provided with a bit of work. When plots are colored by a variable, planets for which that variable is not known will be colored grey."
    ]
   },
   {
@@ -362,55 +335,122 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def gal_map(year_range, cands, hab, esc, size, color):\n",
-    "    filtered_exoplanets = filter_year(exoplanets,year_range)\n",
-    "    if hab:\n",
-    "        filtered_exoplanets = filter_habitable(filtered_exoplanets)\n",
-    "   \n",
-    "    star_background = (stars.hvplot.scatter(**opts,datashade=True,\n",
-    "                                               color=\"phot_g_mean_mag\",cmap=fire,\n",
-    "                                               colorbar=True))\n",
-    "    overlay_points = (filtered_exoplanets.hvplot.scatter(**opts,\n",
-    "                                               color=color, size=size,\n",
-    "                                               clabel=color).opts(cmap='blues'))\n",
-    "\n",
+    "def planets(planets=exoplanets, size=\"radius\", color=\"radius\"):\n",
     "    size_scale = 1 if size == \"radius\" else 0.005\n",
-    "    overlay_points.opts(size = size_scale*hv.dim(size))\n",
-    "    sun = origin.hvplot.scatter(**opts,size=60,color=\"yellow\")\n",
-    "   \n",
-    "    layers = [star_background, overlay_points,sun]\n",
-    "    if cands:\n",
-    "        filtered_candidates = filter_candidates(candidates, year_range)\n",
-    "        candidate_points = (filtered_candidates.hvplot.scatter(x='b',y='l',\n",
-    "                                               size=30,color=\"green\",alpha=0.5))\n",
-    "        layers.append(candidate_points)\n",
-    "    \n",
-    "    if esc:\n",
-    "        escapable = show_escapable(filtered_exoplanets)\n",
-    "        escapable_points = (escapable.hvplot.scatter(**opts,color=\"red\",clabel=color)\n",
-    "                                            .opts(cmap='blues',size=12,alpha=0.5))\n",
-    "        layers.append(escapable_points)\n",
-    "    return hv.Overlay(layers).collate().opts(bgcolor=\"black\",title='Map of exoplanets')"
+    "    points = planets.hvplot.points(**opts, color=color, size=size, clabel=color)\n",
+    "    return points.opts(cmap='blues', size=size_scale*hv.dim(size))\n",
+    "\n",
+    "planets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85f403cc",
+   "metadata": {},
+   "source": [
+    "If we like, we can filter this plot by year and/or by whether it is potentially habitable:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca97d829",
+   "id": "d20696f4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "bound_gm = pn.bind(gal_map,*widgets)\n",
+    "def habitable_exoplanets_by_year(year_range=(-np.inf,np.inf), hab=False):\n",
+    "    \"Exoplanets filtered by the given year range and (if hab=True) whether they are habitable\"\n",
+    "    e = exoplanets\n",
+    "    filtered = e[(e.disc_year>=year_range[0]) & (e.disc_year<=year_range[1])]\n",
+    "    if hab:\n",
+    "        filtered = filtered[filtered.habitable == True].drop_duplicates()\n",
+    "    filtered = filtered.drop_duplicates()\n",
+    "    return filtered\n",
     "\n",
-    "pn.Column(pn.panel(bound_gm))    "
+    "planets(habitable_exoplanets_by_year((1996,2021), True))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "affe438f",
+   "id": "195cf044",
    "metadata": {},
    "source": [
-    "We'll also include a scatterplot of two variables chosen by the user, with points colored according to habitability. First, we'll define a function ``radius_mass`` that outputs the scatterplot with the chosen variables on their respective axes."
+    "We can also filter by whether the planet is potentially escapable with a chemical rocket, which doesn't leave many!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee253de3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def escapable_planets(planets=exoplanets, show=True, color=\"radius\"):\n",
+    "    escapable = planets[planets['escapable']==True]\n",
+    "    escapable_points = escapable.hvplot.points(**opts, color=\"red\", clabel=color)\n",
+    "    return escapable_points.opts(cmap='blues', size=12, alpha=0.5)\n",
+    "\n",
+    "escapable_planets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59d1de75",
+   "metadata": {},
+   "source": [
+    "Separately, we can look at the candidates exoplanets, e.g. to see how their distribution compares with the confirmed exoplanets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "117d35e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def candidate_exoplanets(year_range=(-np.inf,np.inf), show=True):\n",
+    "    \"Filter candidate exoplanets by year range and plot them in b,l space\"\n",
+    "    c=candidates\n",
+    "    filtered_candidates = c[(c.year>=year_range[0]) & (c.year<=year_range[1])]\n",
+    "    return filtered_candidates.hvplot.points(**opts, size=30, color=\"green\", alpha=0.5*int(show))\n",
+    "\n",
+    "candidate_exoplanets()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7a53376",
+   "metadata": {},
+   "source": [
+    "Given that all the above plots share the same x and y axes, we can combine them into a single plot so that you can see everything in context:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37dc73a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "star_background * planets() * escapable_planets() * sun * candidate_exoplanets(show=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3584a329",
+   "metadata": {},
+   "source": [
+    "Whew! That's a bit of a mess. :-) For a user to make much sense of that, we'll need to let them decide what they want to see dynamically; otherwise it's too difficult to see what's what! Later on we'll see how to define some widgets that let them do that. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bcb93e3",
+   "metadata": {},
+   "source": [
+    "## Radius vs. mass\n",
+    "\n",
+    "First, though, let's define a completely different type of visualization, a scatterplot that lets us compare various quantities against each other so that we can see how habitable and uninhabitable exoplanets relate to each other:"
    ]
   },
   {
@@ -420,60 +460,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def radius_mass(x_axis,y_axis):\n",
+    "def scatter(x_axis=\"radius\", y_axis=\"mass\"):\n",
     "    habitable = exoplanets[exoplanets['habitable']==True].dropna(subset=[x_axis, y_axis])\n",
     "    uninhabitable = exoplanets[exoplanets['habitable']==False].dropna(subset=[x_axis, y_axis])\n",
-    "    habitable_points = habitable.hvplot.scatter(x=x_axis,y=y_axis,color=\"red\",\n",
+    "    habitable_points = habitable.hvplot.scatter(x=x_axis,y=y_axis,color=\"red\", responsive=True, aspect=5/2,\n",
     "                                                label=\"Potentially habitable\",size=30).opts(legend_position='top_right')\n",
-    "    uninhabitable_points = uninhabitable.hvplot.scatter(x=x_axis,y=y_axis,\n",
+    "    uninhabitable_points = uninhabitable.hvplot.scatter(x=x_axis,y=y_axis, responsive=True, aspect=5/2,\n",
     "                                                        color=\"blue\",alpha=0.5,\n",
     "                                                        label=\"Uninhabitable\",size=10).opts(legend_position='top_right')\n",
-    "    return uninhabitable_points*habitable_points.opts(title=f'Scatterplot of {x_axis} and {y_axis}')"
+    "    return uninhabitable_points*habitable_points.opts(title=f'Scatterplot of {x_axis} and {y_axis}')\n",
+    "\n",
+    "scatter()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "def5189c",
-   "metadata": {},
-   "source": [
-    "Next, we'll define two dropdown menus to choose the axis variables."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1dc554ef",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x_axis = pn.widgets.Select(name='x-axis:', options={\"Earth radius\":\"radius\", \"Earth mass\":\"mass\",\n",
-    "                                                                   \"Temperature\": \"temperature\"})\n",
-    "y_axis = pn.widgets.Select(name='y-axis:', options={\"Earth mass\":\"mass\",\"Earth radius\":\"radius\",\n",
-    "                                                                   \"Temperature\": \"temperature\"})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7a2f8fd9",
-   "metadata": {},
-   "source": [
-    "We can use ``pn.bind`` to bind the user's axis selections to the plot output."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d13f14c9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bound_rm = pn.bind(radius_mass,x_axis=x_axis,y_axis=y_axis)\n",
-    "pn.Column(bound_rm)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ad385d69",
+   "id": "2c1348f7",
    "metadata": {},
    "source": [
     "In the plot above, we can see that most planets have a mass under 2000 times Earth's and radii under 20 times Earth's, but there are a few outliers. The exoplanet with the largest mass in our dataset is the gas giant [HR 2562-b](https://exoplanets.nasa.gov/exoplanet-catalog/7229/hr-2562-b/), whose mass is over 9000 times Earth's, but whose radius is only about 12 times Earth's.\n",
@@ -483,6 +485,120 @@
     "The hottest planet in our dataset is the gas giant [KELT-9b](https://exoplanets.nasa.gov/exoplanet-catalog/3508/kelt-9-b/), whose surface temperature is 4050 Kelvin, and the coldest is [OGLE-2005-BLG-390L b](https://exoplanets.nasa.gov/exoplanet-catalog/6081/ogle-2005-blg-390l-b/), at only 50 Kelvin. Temperature and radius appear to have a positive correlation.\n",
     "\n",
     "In terms of habitability, all the potentially habitable exoplanets have radius less than five times Earth's, mass less than forty times Earth's, and surface temperature between about 200 and 400 Kelvin. For comparison, Earth's surface temperature is 288 Kelvin."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "735be04e",
+   "metadata": {},
+   "source": [
+    "## Dashboard\n",
+    "\n",
+    "Now that we have our data and plots defined, we can use Panel widgets and layouts to build a shareable dashboard where we can explore all the combinations. \n",
+    "\n",
+    "First, we'll define two dropdown menus to choose the axis variables for the scatter plot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1dc554ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pn.config.sizing_mode=\"stretch_width\"\n",
+    "axis_choices={\"Earth radius\":\"radius\", \"Earth mass\":\"mass\", \"Temperature\": \"temperature\"}\n",
+    "\n",
+    "x_axis = pn.widgets.Select(name='x-axis:', options=axis_choices)\n",
+    "y_axis = pn.widgets.Select(name='y-axis:', options=axis_choices, value='mass')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a2f8fd9",
+   "metadata": {},
+   "source": [
+    "Widgets need to be bound to a function or other dynamic object for them to have any effect. Here, we'll use ``pn.bind`` to bind the user's axis selections to the arguments needed by our plotting function, then display the result along with the widgets:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d13f14c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bound_scatter = pn.bind(scatter, x_axis=x_axis, y_axis=y_axis)\n",
+    "\n",
+    "pn.Column(bound_scatter, pn.Row(x_axis, y_axis))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a405d96e",
+   "metadata": {},
+   "source": [
+    "We can add other widgets controlling the longitude and latitude plots, including a slider representing discovery year, a checkbox determining whether to show unconfirmed exoplanets, a second checkbox determining whether to display only planets in the potentially habitable zone, and two dropdown menus to determine what the size and color of the points on the plot will represent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f795fb58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "year_range      = pn.widgets.RangeSlider( name='Discovery year range', start=1996, end=2021)\n",
+    "show_candidates = pn.widgets.Checkbox(    name='Show unconfirmed exoplanets')\n",
+    "show_habitable  = pn.widgets.Checkbox(    name='Show only planets in potentially habitable zone')\n",
+    "show_escapable  = pn.widgets.Checkbox(    name='Show which planets could be escaped with a chemical rocket')\n",
+    "select_size     = pn.widgets.Select(      name='Size points by:',  options=axis_choices)\n",
+    "select_color    = pn.widgets.Select(      name='Color points by:', options=axis_choices)\n",
+    "\n",
+    "widgets = pn.Column(pn.Row(pn.Column(select_size, select_color),\n",
+    "                    pn.Column(year_range, show_candidates, show_escapable, show_habitable)))\n",
+    "#widgets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fb43712",
+   "metadata": {},
+   "source": [
+    "We'll first bind the filtering widgets to the arguments of our filtering function, to generate a dynamically filtered dataframe that will be used in multiple plots:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93823d87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filtered = pn.bind(habitable_exoplanets_by_year, year_range, show_habitable)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "263f95fe",
+   "metadata": {},
+   "source": [
+    "Now we can bind this dataframe and the other widgets to the various plotting function arguments. We'll wrap the bound functions as HoloViews DynamicMaps so that we can use the HoloViews `*` overlay operator on them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9fbdd80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay = (star_background * \n",
+    "           hv.DynamicMap(pn.bind(planets,              filtered,   select_size,    select_color)) * \n",
+    "           hv.DynamicMap(pn.bind(escapable_planets,    filtered,   show_escapable, select_color)) * \n",
+    "           hv.DynamicMap(pn.bind(candidate_exoplanets, year_range, show_candidates)) *\n",
+    "           sun).opts(title='Map of exoplanets')\n",
+    "#overlay"
    ]
   },
   {
@@ -497,16 +613,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cb3b139",
+   "id": "ed18f6b1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "filtered_view = pn.Row(\n",
-    "    pn.Column(*widgets,pn.Column(bound_gm, width=800),\n",
-    "                pn.Row(pn.Column(x_axis,y_axis),\n",
-    "                pn.Column(bound_rm,width=400))))\n",
+    "text = \"\"\"\n",
+    "# Exoplanets explorer\n",
+    "\"\"\"\n",
     "\n",
-    "filtered_view.servable()"
+    "pn.Row(pn.Column(text, widgets, overlay, bound_scatter, pn.Row(x_axis, y_axis) )).servable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89322641",
+   "metadata": {},
+   "source": [
+    "You can use this app here in the notebook, or serve it as a standalone dashboard using a command like `panel serve --show exoplanets.ipynb`."
    ]
   }
  ],


### PR DESCRIPTION
The exoplanets example looked great, but I kept wanting to be able to see plots on their own, which was difficult when they were all bound together into the `gal_map` function. I've split it into separate plotting functions for each of the items in the overlay, which makes it possible to see how everything fits together and also makes it much easier to e.g. change the format into a layout instead of an overlay if desired. This also let me put all the Panel-dashboard stuff at the very end, cleanly separating the underlying data-manipulation code from the widgets and layouts.

I also vectorized the `deltav` function by rewriting it in terms of numpy calls. Previously it was using Pandas .apply for vectorization, but now it should be faster and simpler to use, working either with apply or simply being passed the entire dataframe.

Remaining issues:
- [x] Chained pn.bind issue? show_candidates only works the first time, to enable showing them; it doesn't let them be turned off afterwards. ETA: turns out to be an hv, not panel, issue.
- [ ] Update holoviews pin to get alpha and visible fixes once released, and re-run `anaconda-project lock`
- [x] Some of the cells could use more explanation -- what are we supposed to see? How do we interpret it?
- [x] I added a title to the final dashboard, but it should probably also have some explanatory text
- [x] Add a template?
