### PR TITLE
Updated bay_trimesh specification and lock file

### DIFF
--- a/bay_trimesh/anaconda-project-lock.yml
+++ b/bay_trimesh/anaconda-project-lock.yml
@@ -17,152 +17,171 @@ locking_enabled: true
 env_specs:
   test:
     locked: true
-    env_spec_hash: 700e7a0cb220e6406e056557e074553d95287570
+    env_spec_hash: 2dd317f1341f9c05efe1e86287cf56d0bc635f4d
     platforms:
     - linux-64
     - osx-64
     - win-64
     packages:
       all:
+      - argcomplete=1.12.3=pyhd3eb1b0_0
       - async_generator=1.10=py37h28b3542_0
+      - atomicwrites=1.4.0=py_0
       - attrs=21.2.0=pyhd3eb1b0_0
       - backcall=0.2.0=pyhd3eb1b0_0
+      - beautifulsoup4=4.10.0=pyh06a4308_0
       - blas=1.0=mkl
-      - bleach=3.3.1=pyhd3eb1b0_0
-      - click-plugins=1.1.1=py_0
+      - bleach=4.0.0=pyhd3eb1b0_0
+      - charset-normalizer=2.0.4=pyhd3eb1b0_0
+      - click-plugins=1.1.1=pyhd3eb1b0_0
       - click=7.1.2=pyhd3eb1b0_0
-      - cloudpickle=1.6.0=py_0
+      - cloudpickle=2.0.0=pyhd3eb1b0_0
       - colorcet=2.0.6=pyhd3eb1b0_0
       - cycler=0.10.0=py37_0
-      - dask-core=2021.7.2=pyhd3eb1b0_0
-      - dask=2021.7.2=pyhd3eb1b0_0
+      - dask-core=2021.10.0=pyhd3eb1b0_0
+      - dask=2021.10.0=pyhd3eb1b0_0
       - datashader=0.13.0=pyhd3eb1b0_1
-      - decorator=5.0.9=pyhd3eb1b0_0
+      - decorator=5.1.0=pyhd3eb1b0_0
       - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py37_0
-      - fsspec=2021.7.0=pyhd3eb1b0_0
+      - fonttools=4.25.0=pyhd3eb1b0_0
+      - fsspec=2021.8.1=pyhd3eb1b0_0
       - geopandas-base=0.9.0=py_1
       - geopandas=0.9.0=py_1
       - geoviews-core=1.9.1=pyh06a4308_0
       - geoviews=1.9.1=pyhd3eb1b0_0
-      - heapdict=1.0.1=py_0
-      - holoviews=1.14.5=pyhd3eb1b0_1
-      - idna=2.10=pyhd3eb1b0_0
-      - importlib_metadata=3.10.0=hd3eb1b0_0
-      - ipykernel=5.3.4=py37h5ca1d4c_0
+      - heapdict=1.0.1=pyhd3eb1b0_0
+      - holoviews=1.14.6=pyhd3eb1b0_1
+      - idna=3.2=pyhd3eb1b0_0
+      - importlib_metadata=4.8.1=hd3eb1b0_0
       - ipython_genutils=0.2.0=pyhd3eb1b0_1
-      - jedi=0.17.0=py37_0
-      - jinja2=3.0.1=pyhd3eb1b0_0
-      - joblib=1.0.1=pyhd3eb1b0_0
-      - jsonschema=3.2.0=py_2
-      - jupyter_client=6.1.12=pyhd3eb1b0_0
+      - jinja2=3.0.2=pyhd3eb1b0_0
+      - joblib=1.1.0=pyhd3eb1b0_0
+      - jsonschema=3.2.0=pyhd3eb1b0_2
+      - jupyter_client=7.0.1=pyhd3eb1b0_0
       - jupyterlab_pygments=0.1.2=py_0
       - mapclassify=2.4.3=pyhd3eb1b0_0
+      - matplotlib-inline=0.1.2=pyhd3eb1b0_2
+      - more-itertools=8.10.0=pyhd3eb1b0_0
       - multipledispatch=0.6.0=py37_0
-      - munch=2.5.0=py_0
+      - munch=2.5.0=pyhd3eb1b0_0
+      - munkres=1.1.4=py_0
       - nbclient=0.5.3=pyhd3eb1b0_0
       - nbformat=5.1.3=pyhd3eb1b0_0
+      - nbsmoke=0.2.8=py37_0
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
-      - networkx=2.6.2=pyhd3eb1b0_0
+      - networkx=2.6.3=pyhd3eb1b0_0
       - olefile=0.46=py37_0
       - packaging=21.0=pyhd3eb1b0_0
-      - panel=0.12.0=pyhd3eb1b0_0
+      - panel=0.12.1=pyhd3eb1b0_0
       - param=1.11.1=pyhd3eb1b0_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
       - pickleshare=0.7.5=pyhd3eb1b0_1003
       - prometheus_client=0.11.0=pyhd3eb1b0_0
-      - prompt-toolkit=3.0.17=pyh06a4308_0
+      - prompt-toolkit=3.0.20=pyhd3eb1b0_0
+      - py=1.10.0=pyhd3eb1b0_0
       - pycparser=2.20=py_2
       - pyct=0.4.8=py37_0
-      - pygments=2.9.0=pyhd3eb1b0_0
-      - pyopenssl=20.0.1=pyhd3eb1b0_1
-      - pyparsing=2.4.7=pyhd3eb1b0_0
+      - pyflakes=2.3.1=pyhd3eb1b0_0
+      - pygments=2.10.0=pyhd3eb1b0_0
+      - pyopenssl=21.0.0=pyhd3eb1b0_1
+      - pyparsing=3.0.4=pyhd3eb1b0_0
       - pyshp=2.1.3=pyhd3eb1b0_0
+      - pytest=4.4.1=py37_0
       - python-dateutil=2.8.2=pyhd3eb1b0_0
-      - pytz=2021.1=pyhd3eb1b0_0
+      - pytz=2021.3=pyhd3eb1b0_0
       - pyviz_comms=2.0.2=pyhd3eb1b0_0
-      - requests=2.25.1=pyhd3eb1b0_0
-      - send2trash=1.5.0=pyhd3eb1b0_1
+      - requests=2.26.0=pyhd3eb1b0_0
+      - send2trash=1.8.0=pyhd3eb1b0_1
       - six=1.16.0=pyhd3eb1b0_0
       - sortedcontainers=2.4.0=pyhd3eb1b0_0
-      - tblib=1.7.0=py_0
+      - soupsieve=2.2.1=pyhd3eb1b0_0
+      - tblib=1.7.0=pyhd3eb1b0_0
       - testpath=0.5.0=pyhd3eb1b0_0
-      - threadpoolctl=2.2.0=pyhb85f177_0
+      - threadpoolctl=2.2.0=pyh0d69192_0
       - toolz=0.11.1=pyhd3eb1b0_0
-      - tqdm=4.62.0=pyhd3eb1b0_1
-      - traitlets=5.0.5=pyhd3eb1b0_0
-      - typing-extensions=3.10.0.0=hd3eb1b0_0
-      - typing_extensions=3.10.0.0=pyh06a4308_0
-      - urllib3=1.26.6=pyhd3eb1b0_1
-      - wcwidth=0.2.5=py_0
+      - tqdm=4.62.3=pyhd3eb1b0_1
+      - traitlets=5.1.0=pyhd3eb1b0_0
+      - typing-extensions=3.10.0.2=hd3eb1b0_0
+      - typing_extensions=3.10.0.2=pyh06a4308_0
+      - urllib3=1.26.7=pyhd3eb1b0_0
+      - wcwidth=0.2.5=pyhd3eb1b0_0
       - webencodings=0.5.1=py37_1
-      - wheel=0.36.2=pyhd3eb1b0_0
+      - wheel=0.37.0=pyhd3eb1b0_1
       - xarray=0.19.0=pyhd3eb1b0_1
       - zict=2.0.0=pyhd3eb1b0_0
-      - zipp=3.5.0=pyhd3eb1b0_0
+      - zipp=3.6.0=pyhd3eb1b0_0
       unix:
       - pexpect=4.8.0=pyhd3eb1b0_3
       - ptyprocess=0.7.0=pyhd3eb1b0_2
       linux-64:
       - _libgcc_mutex=0.1=main
+      - _openmp_mutex=4.5=1_gnu
       - argon2-cffi=20.1.0=py37h27cfd23_1
       - aws-c-common=0.4.57=he6710b0_1
       - aws-c-event-stream=0.1.6=h2531618_5
       - aws-checksums=0.1.9=he6710b0_0
       - aws-sdk-cpp=1.8.185=hce553d0_0
       - bokeh=2.3.3=py37h06a4308_0
+      - brotli=1.0.9=he6710b0_2
       - brotlipy=0.7.0=py37h27cfd23_1003
       - bzip2=1.0.8=h7b6447c_0
-      - ca-certificates=2021.7.5=h06a4308_1
+      - c-ares=1.17.1=h27cfd23_0
+      - ca-certificates=2021.10.26=h06a4308_2
       - cairo=1.16.0=hf32fb01_1
       - cartopy=0.18.0=py37h0d9ca2b_1
-      - certifi=2021.5.30=py37h06a4308_0
+      - certifi=2021.10.8=py37h06a4308_0
       - cffi=1.14.6=py37h400218f_0
       - cfitsio=3.470=hf0d0db6_6
       - cftime=1.5.0=py37h6323ea4_0
-      - chardet=4.0.0=py37h06a4308_1003
       - cligj=0.7.2=py37h06a4308_0
-      - cryptography=3.4.7=py37hd23ed53_0
-      - curl=7.71.1=h8f29fe8_2
+      - cryptography=35.0.0=py37hd23ed53_0
+      - curl=7.78.0=h1ccaba5_0
       - cytoolz=0.11.0=py37h7b6447c_0
       - datashape=0.5.4=py37h06a4308_1
-      - distributed=2021.7.2=py37h06a4308_0
+      - debugpy=1.4.1=py37h295c915_0
+      - distributed=2021.10.0=py37h06a4308_0
       - expat=2.4.1=h2531618_2
       - fiona=1.8.13.post1=py37hc820daa_0
       - fontconfig=2.13.1=h6c09931_0
-      - freetype=2.10.4=h5ab3b9f_0
+      - freetype=2.11.0=h70c0345_0
       - freexl=1.0.6=h27cfd23_0
       - gdal=3.0.2=py37h4694593_1
       - geos=3.8.0=he6710b0_0
       - geotiff=1.6.0=h21e8280_0
       - giflib=5.2.1=h7b6447c_0
-      - glib=2.69.0=h5202010_0
+      - glib=2.69.1=h5202010_0
       - hdf4=4.2.13=h3ca952b_2
       - hdf5=1.10.6=hb1b8bf9_0
       - icu=58.2=he6710b0_3
-      - importlib-metadata=3.10.0=py37h06a4308_0
-      - intel-openmp=2021.3.0=h06a4308_3350
-      - ipython=7.22.0=py37hb070fc8_0
-      - jpeg=9b=h024ee3a_2
+      - importlib-metadata=4.8.1=py37h06a4308_0
+      - intel-openmp=2021.4.0=h06a4308_3561
+      - ipykernel=6.4.1=py37h06a4308_1
+      - ipython=7.29.0=py37hb070fc8_0
+      - jedi=0.18.0=py37h06a4308_1
+      - jpeg=9d=h7f8727e_0
       - json-c=0.13.1=h1bed415_0
-      - jupyter_core=4.7.1=py37h06a4308_0
+      - jupyter_core=4.8.1=py37h06a4308_0
       - kealib=1.4.14=h54c064f_0
       - kiwisolver=1.3.1=py37h2531618_0
       - krb5=1.19.2=hac12032_0
       - lcms2=2.12=h3be6417_0
       - ld_impl_linux-64=2.35.1=h7274673_9
       - libboost=1.73.0=h3ff78a5_11
-      - libcurl=7.71.1=h303737a_2
+      - libcurl=7.78.0=h0b77cf5_0
       - libdap4=3.19.1=h6ec2957_0
-      - libedit=3.1.20210216=h27cfd23_1
+      - libedit=3.1.20210910=h7f8727e_0
+      - libev=4.33=h7f8727e_1
       - libffi=3.3=he6710b0_2
       - libgcc-ng=9.1.0=hdf63c60_0
       - libgdal=3.0.2=h7c14f60_1
       - libgfortran-ng=7.3.0=hdf63c60_0
+      - libgomp=9.3.0=h5101ec6_17
       - libkml=1.3.0=h7ecb851_5
-      - libllvm10=10.0.1=hbcb73fb_5
+      - libllvm11=11.1.0=h3826bc1_0
       - libnetcdf=4.6.1=h2053bdc_4
+      - libnghttp2=1.41.0=hf8bcb03_2
       - libpng=1.6.37=hbc83047_0
       - libpq=12.2=h553bfba_1
       - libsodium=1.0.18=h7b6447c_0
@@ -171,59 +190,61 @@ env_specs:
       - libssh2=1.9.0=h1ba5d50_1
       - libstdcxx-ng=9.1.0=hdf63c60_0
       - libtiff=4.2.0=h85742a9_0
-      - libuuid=1.0.3=h1bed415_2
+      - libuuid=1.0.3=h7f8727e_2
       - libwebp-base=1.2.0=h27cfd23_0
+      - libwebp=1.2.0=h89dd481_0
       - libxcb=1.14=h7b6447c_0
       - libxml2=2.9.10=hb55368b_3
-      - llvmlite=0.36.0=py37h612dafd_4
+      - llvmlite=0.37.0=py37h295c915_1
       - locket=0.2.1=py37h06a4308_1
-      - lz4-c=1.9.3=h2531618_0
+      - lz4-c=1.9.3=h295c915_1
       - markdown=3.3.4=py37h06a4308_0
       - markupsafe=2.0.1=py37h27cfd23_0
-      - matplotlib-base=3.3.4=py37h62a2d02_0
+      - matplotlib-base=3.4.3=py37hbbc1b5f_0
       - mistune=0.8.4=py37h14c3975_1001
       - mkl-service=2.4.0=py37h7f8727e_0
-      - mkl=2021.3.0=h06a4308_520
-      - mkl_fft=1.3.0=py37h42c9631_2
+      - mkl=2021.4.0=h06a4308_640
+      - mkl_fft=1.3.1=py37hd3c417c_0
       - mkl_random=1.2.2=py37h51133e4_0
       - msgpack-python=1.0.2=py37hff7bd54_1
       - nbconvert=6.1.0=py37h06a4308_0
-      - ncurses=6.2=he6710b0_1
+      - ncurses=6.3=heee7806_1
       - netcdf4=1.5.7=py37h0a24e14_0
-      - notebook=6.4.0=py37h06a4308_0
-      - numba=0.53.1=py37ha9443f7_0
+      - notebook=6.4.5=py37h06a4308_0
+      - numba=0.54.1=py37h51133e4_0
       - numpy-base=1.20.3=py37h74d4b33_0
       - numpy=1.20.3=py37hf144106_0
-      - openjpeg=2.3.0=h05c96fa_1
-      - openssl=1.1.1k=h27cfd23_0
+      - openjpeg=2.4.0=h3ad879b_0
+      - openssl=1.1.1l=h7f8727e_0
       - pandas=1.2.5=py37h295c915_0
       - pandocfilters=1.4.3=py37h06a4308_1
       - pcre=8.45=h295c915_0
-      - pillow=8.3.1=py37h2c7a002_0
+      - pillow=8.4.0=py37h5aabda8_0
       - pip=21.2.2=py37h06a4308_0
-      - pixman=0.40.0=h7b6447c_0
+      - pixman=0.40.0=h7f8727e_1
+      - pluggy=1.0.0=py37h06a4308_0
       - poppler-data=0.4.10=h06a4308_0
       - poppler=0.81.0=h01f5e8b_2
       - postgresql=12.2=h553bfba_1
       - proj=6.2.1=haa6030c_0
       - psutil=5.8.0=py37h27cfd23_1
       - pyproj=2.6.1.post1=py37hb3025e9_1
-      - pyrsistent=0.17.3=py37h7b6447c_0
+      - pyrsistent=0.18.0=py37heee7806_0
       - pysocks=1.7.1=py37_1
       - python=3.7.11=h12debd9_0
-      - pyyaml=5.4.1=py37h27cfd23_1
-      - pyzmq=20.0.0=py37h2531618_1
+      - pyyaml=6.0=py37h7f8727e_1
+      - pyzmq=22.2.1=py37h295c915_1
       - readline=8.1=h27cfd23_0
       - rtree=0.9.7=py37h06a4308_1
-      - scikit-learn=0.24.2=py37ha9443f7_0
+      - scikit-learn=1.0.1=py37h51133e4_0
       - scipy=1.6.2=py37had2a1c9_1
-      - setuptools=52.0.0=py37h06a4308_0
-      - shapely=1.7.1=py37h98ec03d_0
+      - setuptools=58.0.4=py37h06a4308_0
+      - shapely=1.7.1=py37h1728cc4_0
       - sqlite=3.36.0=hc218d9a_0
-      - tbb=2020.3=hfd86e86_0
+      - tbb=2021.4.0=hd09550d_0
       - terminado=0.9.4=py37h06a4308_0
       - tiledb=2.2.9=hffe1d7a_0
-      - tk=8.6.10=hbc83047_0
+      - tk=8.6.11=h1ccaba5_0
       - tornado=6.1=py37h27cfd23_0
       - xerces-c=3.2.3=h780794e_0
       - xz=5.2.5=h7b6447c_0
@@ -242,57 +263,61 @@ env_specs:
       - brotli=1.0.9=hb1e8313_2
       - brotlipy=0.7.0=py37h9ed2024_1003
       - bzip2=1.0.8=h1de35cc_0
-      - ca-certificates=2021.7.5=hecd8cb5_1
+      - c-ares=1.17.1=h9ed2024_0
+      - ca-certificates=2021.10.26=hecd8cb5_2
       - cairo=1.16.0=h8023c5d_1
       - cartopy=0.18.0=py37hf1ba7ce_1
-      - certifi=2021.5.30=py37hecd8cb5_0
+      - certifi=2021.10.8=py37hecd8cb5_0
       - cffi=1.14.6=py37h2125817_0
       - cfitsio=3.470=hee0f690_6
       - cftime=1.5.0=py37he3068b8_0
-      - chardet=4.0.0=py37hecd8cb5_1003
       - cligj=0.7.2=py37hecd8cb5_0
-      - cryptography=3.4.7=py37h2fd3fbb_0
-      - curl=7.71.1=h7bc2e8c_2
+      - cryptography=35.0.0=py37h2fd3fbb_0
+      - curl=7.78.0=h7bc2e8c_0
       - cytoolz=0.11.0=py37haf1e3a3_0
       - datashape=0.5.4=py37hecd8cb5_1
-      - distributed=2021.7.2=py37hecd8cb5_0
+      - debugpy=1.4.1=py37h23ab428_0
+      - distributed=2021.10.0=py37hecd8cb5_0
       - expat=2.4.1=h23ab428_2
       - fiona=1.8.13.post1=py37h9c05f0f_0
       - fontconfig=2.13.1=ha9ee91d_0
-      - fonttools=4.25.0=pyhd3eb1b0_0
-      - freetype=2.10.4=ha233b18_0
+      - freetype=2.11.0=hd8bbffd_0
       - freexl=1.0.6=h9ed2024_0
       - gdal=3.0.2=py37ha6ec53f_1
       - geos=3.8.0=hb1e8313_0
       - geotiff=1.6.0=h02c1893_0
       - gettext=0.21.0=h7535e17_0
       - giflib=5.2.1=haf1e3a3_0
-      - glib=2.69.0=hdf23fa2_0
+      - glib=2.69.1=hdf23fa2_0
       - hdf4=4.2.13=h39711bb_2
       - hdf5=1.10.6=hdbbcd12_0
       - icu=58.2=h0a44026_3
-      - importlib-metadata=3.10.0=py37hecd8cb5_0
-      - intel-openmp=2021.3.0=hecd8cb5_3375
-      - ipython=7.22.0=py37h01d92e1_0
-      - jpeg=9b=he5867d9_2
+      - importlib-metadata=4.8.1=py37hecd8cb5_0
+      - intel-openmp=2021.4.0=hecd8cb5_3538
+      - ipykernel=6.4.1=py37hecd8cb5_1
+      - ipython=7.29.0=py37h01d92e1_0
+      - jedi=0.18.0=py37hecd8cb5_1
+      - jpeg=9d=h9ed2024_0
       - json-c=0.13.1=h3efe00b_0
-      - jupyter_core=4.7.1=py37hecd8cb5_0
+      - jupyter_core=4.8.1=py37hecd8cb5_0
       - kealib=1.4.14=h7bbef82_0
       - kiwisolver=1.3.1=py37h23ab428_0
       - krb5=1.19.2=hcd88c3b_0
       - lcms2=2.12=hf1fd2bf_0
       - libboost=1.73.0=hd4c2dcd_11
-      - libcurl=7.71.1=hb8e4fae_2
-      - libcxx=10.0.0=1
+      - libcurl=7.78.0=hb8e4fae_0
+      - libcxx=12.0.0=h2f01273_0
       - libdap4=3.19.1=h3d3e54a_0
-      - libedit=3.1.20210216=h9ed2024_1
+      - libedit=3.1.20210910=hca72f7f_0
+      - libev=4.33=h9ed2024_1
       - libffi=3.3=hb1e8313_2
       - libgdal=3.0.2=ha1444b2_1
       - libgfortran=3.0.1=h93005f0_2
       - libiconv=1.16=h1de35cc_0
       - libkml=1.3.0=h952ee91_5
-      - libllvm10=10.0.1=h76017ad_5
+      - libllvm11=11.1.0=h9b2ccf5_0
       - libnetcdf=4.6.1=hfd9a460_4
+      - libnghttp2=1.41.0=h7580e61_2
       - libpng=1.6.37=ha441bb4_0
       - libpq=12.2=h1b4eb34_1
       - libsodium=1.0.18=h1de35cc_0
@@ -301,57 +326,59 @@ env_specs:
       - libssh2=1.9.0=ha12b0ac_1
       - libtiff=4.2.0=h87d7836_0
       - libwebp-base=1.2.0=h9ed2024_0
+      - libwebp=1.2.0=hacca55c_0
       - libxml2=2.9.12=hcdb78fc_0
-      - llvm-openmp=10.0.0=h28b9765_0
-      - llvmlite=0.36.0=py37he4411ff_4
+      - llvm-openmp=12.0.0=h0dcd299_1
+      - llvmlite=0.37.0=py37he4411ff_1
       - locket=0.2.1=py37hecd8cb5_1
-      - lz4-c=1.9.3=h23ab428_0
+      - lz4-c=1.9.3=h23ab428_1
       - markdown=3.3.4=py37hecd8cb5_0
       - markupsafe=2.0.1=py37h9ed2024_0
-      - matplotlib-base=3.4.2=py37h8b3ea08_0
+      - matplotlib-base=3.4.3=py37h0a11d32_0
       - mistune=0.8.4=py37h1de35cc_0
       - mkl-service=2.4.0=py37h9ed2024_0
-      - mkl=2021.3.0=hecd8cb5_517
-      - mkl_fft=1.3.0=py37h4a7008c_2
+      - mkl=2021.4.0=hecd8cb5_637
+      - mkl_fft=1.3.1=py37h4ab4a9b_0
       - mkl_random=1.2.2=py37hb2f4e1b_0
       - msgpack-python=1.0.2=py37hf7b0b51_1
-      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37hecd8cb5_0
-      - ncurses=6.2=h0a44026_1
+      - ncurses=6.3=hca72f7f_1
       - netcdf4=1.5.7=py37h1695cb1_0
-      - notebook=6.4.0=py37hecd8cb5_0
-      - numba=0.53.0=py37hb2f4e1b_0
+      - notebook=6.4.5=py37hecd8cb5_0
+      - numba=0.54.1=py37hae1ba45_0
       - numpy-base=1.20.3=py37he0bd621_0
       - numpy=1.20.3=py37h4b4dc7a_0
-      - openjpeg=2.3.0=hb95cd4c_1
-      - openssl=1.1.1k=h9ed2024_0
+      - openjpeg=2.4.0=h66ea3da_0
+      - openssl=1.1.1l=h9ed2024_0
       - pandas=1.2.5=py37h23ab428_0
       - pandocfilters=1.4.3=py37hecd8cb5_1
       - pcre=8.45=h23ab428_0
-      - pillow=8.3.1=py37ha4cf6ea_0
+      - pillow=8.4.0=py37h98e4679_0
       - pip=21.2.2=py37hecd8cb5_0
-      - pixman=0.40.0=haf1e3a3_0
+      - pixman=0.40.0=h9ed2024_1
+      - pluggy=1.0.0=py37hecd8cb5_0
       - poppler-data=0.4.10=hecd8cb5_0
       - poppler=0.81.0=h031bf0f_2
       - postgresql=12.2=h1b4eb34_1
       - proj=6.2.1=hfd5b9e3_0
       - psutil=5.8.0=py37h9ed2024_1
       - pyproj=2.6.1.post1=py37hdfdfadc_1
-      - pyrsistent=0.17.3=py37haf1e3a3_0
+      - pyrsistent=0.18.0=py37hca72f7f_0
       - pysocks=1.7.1=py37hecd8cb5_0
       - python=3.7.11=h88f2d9e_0
-      - pyyaml=5.4.1=py37h9ed2024_1
-      - pyzmq=20.0.0=py37h23ab428_1
+      - pyyaml=6.0=py37hca72f7f_1
+      - pyzmq=22.2.1=py37h23ab428_1
       - readline=8.1=h9ed2024_0
       - rtree=0.9.7=py37hecd8cb5_1
-      - scikit-learn=0.24.2=py37hb2f4e1b_0
-      - scipy=1.6.2=py37hd5f7400_1
-      - setuptools=52.0.0=py37hecd8cb5_0
-      - shapely=1.7.1=py37hb435bde_0
+      - scikit-learn=1.0.1=py37hae1ba45_0
+      - scipy=1.7.1=py37h88652d9_2
+      - setuptools=58.0.4=py37hecd8cb5_0
+      - shapely=1.7.1=py37h9250791_0
       - sqlite=3.36.0=hce871da_0
+      - tbb=2021.4.0=haf03e11_0
       - terminado=0.9.4=py37hecd8cb5_0
       - tiledb=2.2.9=hdc16fd3_0
-      - tk=8.6.10=hb0a8c7a_0
+      - tk=8.6.11=h7bc2e8c_0
       - tornado=6.1=py37h9ed2024_0
       - xerces-c=3.2.3=h48eee30_0
       - xz=5.2.5=h1de35cc_0
@@ -369,24 +396,23 @@ env_specs:
       - brotli=1.0.9=ha925a31_2
       - brotlipy=0.7.0=py37h2bbff1b_1003
       - bzip2=1.0.8=he774522_0
-      - ca-certificates=2021.7.5=haa95532_1
+      - ca-certificates=2021.10.26=haa95532_2
       - cartopy=0.18.0=py37h80a4efb_1
-      - certifi=2021.5.30=py37haa95532_0
+      - certifi=2021.10.8=py37haa95532_0
       - cffi=1.14.6=py37h2bbff1b_0
       - cfitsio=3.470=he774522_6
       - cftime=1.5.0=py37h080aedc_0
-      - chardet=4.0.0=py37haa95532_1003
       - cligj=0.7.2=py37haa95532_0
       - colorama=0.4.4=pyhd3eb1b0_0
-      - cryptography=3.4.7=py37h71e12ea_0
-      - curl=7.71.1=h86230a5_2
+      - cryptography=35.0.0=py37h71e12ea_0
+      - curl=7.78.0=h86230a5_0
       - cytoolz=0.11.0=py37he774522_0
       - datashape=0.5.4=py37haa95532_1
-      - distributed=2021.7.2=py37haa95532_0
+      - debugpy=1.4.1=py37hd77b12b_0
+      - distributed=2021.10.0=py37haa95532_0
       - expat=2.4.1=h6c2663c_2
-      - fiona=1.8.13.post1=py37hd760492_0
-      - fonttools=4.25.0=pyhd3eb1b0_0
-      - freetype=2.10.4=hd328e21_0
+      - fiona=1.8.13.post1=py37h758c064_0
+      - freetype=2.11.0=ha860e81_0
       - freexl=1.0.6=h2bbff1b_0
       - gdal=3.0.2=py37hb978731_1
       - geos=3.8.0=h33f27b4_0
@@ -394,29 +420,31 @@ env_specs:
       - hdf4=4.2.13=h712560f_2
       - hdf5=1.10.6=h7ebc959_0
       - icc_rt=2019.0.0=h0cc432a_1
-      - importlib-metadata=3.10.0=py37haa95532_0
-      - intel-openmp=2021.3.0=haa95532_3372
-      - ipython=7.22.0=py37hd4e2768_0
-      - jpeg=9b=hb83a4c4_2
-      - jupyter_core=4.7.1=py37haa95532_0
+      - importlib-metadata=4.8.1=py37haa95532_0
+      - intel-openmp=2021.4.0=haa95532_3556
+      - ipykernel=6.4.1=py37haa95532_1
+      - ipython=7.29.0=py37hd4e2768_0
+      - jedi=0.18.0=py37haa95532_1
+      - jpeg=9d=h2bbff1b_0
+      - jupyter_core=4.8.1=py37haa95532_0
       - kealib=1.4.14=hde4a422_0
       - kiwisolver=1.3.1=py37hd77b12b_0
       - krb5=1.19.2=h5b6d351_0
-      - libcurl=7.71.1=h86230a5_2
+      - libcurl=7.78.0=h86230a5_0
       - libgdal=3.0.2=ha1b3edf_1
       - libiconv=1.15=h1df5818_7
       - libnetcdf=4.6.1=hf59b723_4
       - libpng=1.6.37=h2a8f88b_0
       - libpq=12.2=hb652d5d_1
-      - libsodium=1.0.18=h62dcd97_0
       - libspatialindex=1.9.3=h6c2663c_0
       - libspatialite=4.3.0a=h7ffb84d_0
       - libssh2=1.9.0=h7a1dbc1_1
       - libtiff=4.2.0=hd0e1b90_0
+      - libwebp=1.2.0=h2bbff1b_0
       - libxml2=2.9.12=h0ad7f3c_0
-      - llvmlite=0.36.0=py37h34b8924_4
+      - llvmlite=0.37.0=py37h23ce68f_1
       - locket=0.2.1=py37haa95532_1
-      - lz4-c=1.9.3=h2bbff1b_0
+      - lz4-c=1.9.3=h2bbff1b_1
       - m2w64-expat=2.1.1=2
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
@@ -428,57 +456,57 @@ env_specs:
       - m2w64-xz=5.2.2=2
       - markdown=3.3.4=py37haa95532_0
       - markupsafe=2.0.1=py37h2bbff1b_0
-      - matplotlib-base=3.4.2=py37h49ac443_0
+      - matplotlib-base=3.4.3=py37h49ac443_0
       - mistune=0.8.4=py37hfa6e2cd_1001
       - mkl-service=2.4.0=py37h2bbff1b_0
-      - mkl=2021.3.0=haa95532_524
-      - mkl_fft=1.3.0=py37h277e83a_2
+      - mkl=2021.4.0=haa95532_640
+      - mkl_fft=1.3.1=py37h277e83a_0
       - mkl_random=1.2.2=py37hf11a4ad_0
       - msgpack-python=1.0.2=py37h59b6b97_1
       - msys2-conda-epoch=20160418=1
-      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37haa95532_0
       - netcdf4=1.5.7=py37hb33177a_0
-      - notebook=6.4.0=py37haa95532_0
-      - numba=0.53.0=py37hf11a4ad_0
+      - notebook=6.4.5=py37haa95532_0
+      - numba=0.54.1=py37hf11a4ad_0
       - numpy-base=1.20.3=py37hc2deb75_0
       - numpy=1.20.3=py37ha4e8547_0
-      - openjpeg=2.3.0=h5ec785f_1
-      - openssl=1.1.1k=h2bbff1b_0
+      - openjpeg=2.4.0=h4fc8c34_0
+      - openssl=1.1.1l=h2bbff1b_0
       - pandas=1.2.5=py37hd77b12b_0
       - pandocfilters=1.4.3=py37haa95532_1
-      - pillow=8.3.1=py37h4fa10fc_0
-      - pip=21.2.2=py37haa95532_0
+      - pillow=8.4.0=py37hd45dc43_0
+      - pip=21.2.4=py37haa95532_0
+      - pluggy=1.0.0=py37haa95532_0
       - postgresql=12.2=hb652d5d_1
       - proj=6.2.1=h9f7ef89_0
       - psutil=5.8.0=py37h2bbff1b_1
       - pyproj=2.6.1.post1=py37h593ac45_1
-      - pyrsistent=0.17.3=py37he774522_0
+      - pyrsistent=0.18.0=py37h196d8e1_0
       - pysocks=1.7.1=py37_1
       - python=3.7.11=h6244533_0
       - pywin32=228=py37hbaba5e8_1
       - pywinpty=0.5.7=py37_0
-      - pyyaml=5.4.1=py37h2bbff1b_1
-      - pyzmq=20.0.0=py37hd77b12b_1
+      - pyyaml=6.0=py37h2bbff1b_1
+      - pyzmq=22.2.1=py37hd77b12b_1
       - rtree=0.9.7=py37h2eaa2aa_1
-      - scikit-learn=0.24.2=py37hf11a4ad_1
-      - scipy=1.6.2=py37h66253e8_1
-      - setuptools=52.0.0=py37haa95532_0
-      - shapely=1.7.1=py37h210f175_0
+      - scikit-learn=1.0.1=py37hf11a4ad_0
+      - scipy=1.7.1=py37hbe87c03_2
+      - setuptools=58.0.4=py37haa95532_0
+      - shapely=1.7.1=py37h06580b3_0
       - sqlite=3.36.0=h2bbff1b_0
+      - tbb=2021.4.0=h59b6b97_0
       - terminado=0.9.4=py37haa95532_0
       - tiledb=2.2.9=hf7ce2e6_0
-      - tk=8.6.10=he774522_0
+      - tk=8.6.11=h2bbff1b_0
       - tornado=6.1=py37h2bbff1b_0
       - vc=14.2=h21ff451_1
       - vs2015_runtime=14.27.29016=h5e58377_2
       - win_inet_pton=1.1.0=py37haa95532_0
-      - wincertstore=0.2=py37_0
+      - wincertstore=0.2=py37haa95532_2
       - winpty=0.4.3=4
       - xerces-c=3.2.3=ha925a31_0
       - xz=5.2.5=h62dcd97_0
       - yaml=0.2.5=he774522_0
-      - zeromq=4.3.3=ha925a31_3
       - zlib=1.2.11=h62dcd97_4
       - zstd=1.4.9=h19a0ad4_0
   default:
@@ -490,145 +518,156 @@ env_specs:
     - win-64
     packages:
       all:
+      - argcomplete=1.12.3=pyhd3eb1b0_0
       - async_generator=1.10=py37h28b3542_0
       - attrs=21.2.0=pyhd3eb1b0_0
       - backcall=0.2.0=pyhd3eb1b0_0
       - blas=1.0=mkl
-      - bleach=3.3.1=pyhd3eb1b0_0
-      - click-plugins=1.1.1=py_0
+      - bleach=4.0.0=pyhd3eb1b0_0
+      - charset-normalizer=2.0.4=pyhd3eb1b0_0
+      - click-plugins=1.1.1=pyhd3eb1b0_0
       - click=7.1.2=pyhd3eb1b0_0
-      - cloudpickle=1.6.0=py_0
+      - cloudpickle=2.0.0=pyhd3eb1b0_0
       - colorcet=2.0.6=pyhd3eb1b0_0
       - cycler=0.10.0=py37_0
-      - dask-core=2021.7.2=pyhd3eb1b0_0
-      - dask=2021.7.2=pyhd3eb1b0_0
+      - dask-core=2021.10.0=pyhd3eb1b0_0
+      - dask=2021.10.0=pyhd3eb1b0_0
       - datashader=0.13.0=pyhd3eb1b0_1
-      - decorator=5.0.9=pyhd3eb1b0_0
+      - decorator=5.1.0=pyhd3eb1b0_0
       - defusedxml=0.7.1=pyhd3eb1b0_0
       - entrypoints=0.3=py37_0
-      - fsspec=2021.7.0=pyhd3eb1b0_0
+      - fonttools=4.25.0=pyhd3eb1b0_0
+      - fsspec=2021.8.1=pyhd3eb1b0_0
       - geopandas-base=0.9.0=py_1
       - geopandas=0.9.0=py_1
       - geoviews-core=1.9.1=pyh06a4308_0
       - geoviews=1.9.1=pyhd3eb1b0_0
-      - heapdict=1.0.1=py_0
-      - holoviews=1.14.5=pyhd3eb1b0_1
-      - idna=2.10=pyhd3eb1b0_0
-      - importlib_metadata=3.10.0=hd3eb1b0_0
-      - ipykernel=5.3.4=py37h5ca1d4c_0
+      - heapdict=1.0.1=pyhd3eb1b0_0
+      - holoviews=1.14.6=pyhd3eb1b0_1
+      - idna=3.2=pyhd3eb1b0_0
+      - importlib_metadata=4.8.1=hd3eb1b0_0
       - ipython_genutils=0.2.0=pyhd3eb1b0_1
-      - jedi=0.17.0=py37_0
-      - jinja2=3.0.1=pyhd3eb1b0_0
-      - joblib=1.0.1=pyhd3eb1b0_0
-      - jsonschema=3.2.0=py_2
-      - jupyter_client=6.1.12=pyhd3eb1b0_0
+      - jinja2=3.0.2=pyhd3eb1b0_0
+      - joblib=1.1.0=pyhd3eb1b0_0
+      - jsonschema=3.2.0=pyhd3eb1b0_2
+      - jupyter_client=7.0.1=pyhd3eb1b0_0
       - jupyterlab_pygments=0.1.2=py_0
       - mapclassify=2.4.3=pyhd3eb1b0_0
+      - matplotlib-inline=0.1.2=pyhd3eb1b0_2
       - multipledispatch=0.6.0=py37_0
-      - munch=2.5.0=py_0
+      - munch=2.5.0=pyhd3eb1b0_0
+      - munkres=1.1.4=py_0
       - nbclient=0.5.3=pyhd3eb1b0_0
       - nbformat=5.1.3=pyhd3eb1b0_0
       - nest-asyncio=1.5.1=pyhd3eb1b0_0
-      - networkx=2.6.2=pyhd3eb1b0_0
+      - networkx=2.6.3=pyhd3eb1b0_0
       - olefile=0.46=py37_0
       - packaging=21.0=pyhd3eb1b0_0
-      - panel=0.12.0=pyhd3eb1b0_0
+      - panel=0.12.1=pyhd3eb1b0_0
       - param=1.11.1=pyhd3eb1b0_0
       - parso=0.8.2=pyhd3eb1b0_0
       - partd=1.2.0=pyhd3eb1b0_0
       - pickleshare=0.7.5=pyhd3eb1b0_1003
       - prometheus_client=0.11.0=pyhd3eb1b0_0
-      - prompt-toolkit=3.0.17=pyh06a4308_0
+      - prompt-toolkit=3.0.20=pyhd3eb1b0_0
       - pycparser=2.20=py_2
       - pyct=0.4.8=py37_0
-      - pygments=2.9.0=pyhd3eb1b0_0
-      - pyopenssl=20.0.1=pyhd3eb1b0_1
-      - pyparsing=2.4.7=pyhd3eb1b0_0
+      - pygments=2.10.0=pyhd3eb1b0_0
+      - pyopenssl=21.0.0=pyhd3eb1b0_1
+      - pyparsing=3.0.4=pyhd3eb1b0_0
       - pyshp=2.1.3=pyhd3eb1b0_0
       - python-dateutil=2.8.2=pyhd3eb1b0_0
-      - pytz=2021.1=pyhd3eb1b0_0
+      - pytz=2021.3=pyhd3eb1b0_0
       - pyviz_comms=2.0.2=pyhd3eb1b0_0
-      - requests=2.25.1=pyhd3eb1b0_0
-      - send2trash=1.5.0=pyhd3eb1b0_1
+      - requests=2.26.0=pyhd3eb1b0_0
+      - send2trash=1.8.0=pyhd3eb1b0_1
       - six=1.16.0=pyhd3eb1b0_0
       - sortedcontainers=2.4.0=pyhd3eb1b0_0
-      - tblib=1.7.0=py_0
+      - tblib=1.7.0=pyhd3eb1b0_0
       - testpath=0.5.0=pyhd3eb1b0_0
-      - threadpoolctl=2.2.0=pyhb85f177_0
+      - threadpoolctl=2.2.0=pyh0d69192_0
       - toolz=0.11.1=pyhd3eb1b0_0
-      - tqdm=4.62.0=pyhd3eb1b0_1
-      - traitlets=5.0.5=pyhd3eb1b0_0
-      - typing-extensions=3.10.0.0=hd3eb1b0_0
-      - typing_extensions=3.10.0.0=pyh06a4308_0
-      - urllib3=1.26.6=pyhd3eb1b0_1
-      - wcwidth=0.2.5=py_0
+      - tqdm=4.62.3=pyhd3eb1b0_1
+      - traitlets=5.1.0=pyhd3eb1b0_0
+      - typing-extensions=3.10.0.2=hd3eb1b0_0
+      - typing_extensions=3.10.0.2=pyh06a4308_0
+      - urllib3=1.26.7=pyhd3eb1b0_0
+      - wcwidth=0.2.5=pyhd3eb1b0_0
       - webencodings=0.5.1=py37_1
-      - wheel=0.36.2=pyhd3eb1b0_0
+      - wheel=0.37.0=pyhd3eb1b0_1
       - xarray=0.19.0=pyhd3eb1b0_1
       - zict=2.0.0=pyhd3eb1b0_0
-      - zipp=3.5.0=pyhd3eb1b0_0
+      - zipp=3.6.0=pyhd3eb1b0_0
       unix:
       - pexpect=4.8.0=pyhd3eb1b0_3
       - ptyprocess=0.7.0=pyhd3eb1b0_2
       linux-64:
       - _libgcc_mutex=0.1=main
+      - _openmp_mutex=4.5=1_gnu
       - argon2-cffi=20.1.0=py37h27cfd23_1
       - aws-c-common=0.4.57=he6710b0_1
       - aws-c-event-stream=0.1.6=h2531618_5
       - aws-checksums=0.1.9=he6710b0_0
       - aws-sdk-cpp=1.8.185=hce553d0_0
       - bokeh=2.3.3=py37h06a4308_0
+      - brotli=1.0.9=he6710b0_2
       - brotlipy=0.7.0=py37h27cfd23_1003
       - bzip2=1.0.8=h7b6447c_0
-      - ca-certificates=2021.7.5=h06a4308_1
+      - c-ares=1.17.1=h27cfd23_0
+      - ca-certificates=2021.10.26=h06a4308_2
       - cairo=1.16.0=hf32fb01_1
       - cartopy=0.18.0=py37h0d9ca2b_1
-      - certifi=2021.5.30=py37h06a4308_0
+      - certifi=2021.10.8=py37h06a4308_0
       - cffi=1.14.6=py37h400218f_0
       - cfitsio=3.470=hf0d0db6_6
       - cftime=1.5.0=py37h6323ea4_0
-      - chardet=4.0.0=py37h06a4308_1003
       - cligj=0.7.2=py37h06a4308_0
-      - cryptography=3.4.7=py37hd23ed53_0
-      - curl=7.71.1=h8f29fe8_2
+      - cryptography=35.0.0=py37hd23ed53_0
+      - curl=7.78.0=h1ccaba5_0
       - cytoolz=0.11.0=py37h7b6447c_0
       - datashape=0.5.4=py37h06a4308_1
-      - distributed=2021.7.2=py37h06a4308_0
+      - debugpy=1.4.1=py37h295c915_0
+      - distributed=2021.10.0=py37h06a4308_0
       - expat=2.4.1=h2531618_2
       - fiona=1.8.13.post1=py37hc820daa_0
       - fontconfig=2.13.1=h6c09931_0
-      - freetype=2.10.4=h5ab3b9f_0
+      - freetype=2.11.0=h70c0345_0
       - freexl=1.0.6=h27cfd23_0
       - gdal=3.0.2=py37h4694593_1
       - geos=3.8.0=he6710b0_0
       - geotiff=1.6.0=h21e8280_0
       - giflib=5.2.1=h7b6447c_0
-      - glib=2.69.0=h5202010_0
+      - glib=2.69.1=h5202010_0
       - hdf4=4.2.13=h3ca952b_2
       - hdf5=1.10.6=hb1b8bf9_0
       - icu=58.2=he6710b0_3
-      - importlib-metadata=3.10.0=py37h06a4308_0
-      - intel-openmp=2021.3.0=h06a4308_3350
-      - ipython=7.22.0=py37hb070fc8_0
-      - jpeg=9b=h024ee3a_2
+      - importlib-metadata=4.8.1=py37h06a4308_0
+      - intel-openmp=2021.4.0=h06a4308_3561
+      - ipykernel=6.4.1=py37h06a4308_1
+      - ipython=7.29.0=py37hb070fc8_0
+      - jedi=0.18.0=py37h06a4308_1
+      - jpeg=9d=h7f8727e_0
       - json-c=0.13.1=h1bed415_0
-      - jupyter_core=4.7.1=py37h06a4308_0
+      - jupyter_core=4.8.1=py37h06a4308_0
       - kealib=1.4.14=h54c064f_0
       - kiwisolver=1.3.1=py37h2531618_0
       - krb5=1.19.2=hac12032_0
       - lcms2=2.12=h3be6417_0
       - ld_impl_linux-64=2.35.1=h7274673_9
       - libboost=1.73.0=h3ff78a5_11
-      - libcurl=7.71.1=h303737a_2
+      - libcurl=7.78.0=h0b77cf5_0
       - libdap4=3.19.1=h6ec2957_0
-      - libedit=3.1.20210216=h27cfd23_1
+      - libedit=3.1.20210910=h7f8727e_0
+      - libev=4.33=h7f8727e_1
       - libffi=3.3=he6710b0_2
       - libgcc-ng=9.1.0=hdf63c60_0
       - libgdal=3.0.2=h7c14f60_1
       - libgfortran-ng=7.3.0=hdf63c60_0
+      - libgomp=9.3.0=h5101ec6_17
       - libkml=1.3.0=h7ecb851_5
-      - libllvm10=10.0.1=hbcb73fb_5
+      - libllvm11=11.1.0=h3826bc1_0
       - libnetcdf=4.6.1=h2053bdc_4
+      - libnghttp2=1.41.0=hf8bcb03_2
       - libpng=1.6.37=hbc83047_0
       - libpq=12.2=h553bfba_1
       - libsodium=1.0.18=h7b6447c_0
@@ -637,59 +676,60 @@ env_specs:
       - libssh2=1.9.0=h1ba5d50_1
       - libstdcxx-ng=9.1.0=hdf63c60_0
       - libtiff=4.2.0=h85742a9_0
-      - libuuid=1.0.3=h1bed415_2
+      - libuuid=1.0.3=h7f8727e_2
       - libwebp-base=1.2.0=h27cfd23_0
+      - libwebp=1.2.0=h89dd481_0
       - libxcb=1.14=h7b6447c_0
       - libxml2=2.9.10=hb55368b_3
-      - llvmlite=0.36.0=py37h612dafd_4
+      - llvmlite=0.37.0=py37h295c915_1
       - locket=0.2.1=py37h06a4308_1
-      - lz4-c=1.9.3=h2531618_0
+      - lz4-c=1.9.3=h295c915_1
       - markdown=3.3.4=py37h06a4308_0
       - markupsafe=2.0.1=py37h27cfd23_0
-      - matplotlib-base=3.3.4=py37h62a2d02_0
+      - matplotlib-base=3.4.3=py37hbbc1b5f_0
       - mistune=0.8.4=py37h14c3975_1001
       - mkl-service=2.4.0=py37h7f8727e_0
-      - mkl=2021.3.0=h06a4308_520
-      - mkl_fft=1.3.0=py37h42c9631_2
+      - mkl=2021.4.0=h06a4308_640
+      - mkl_fft=1.3.1=py37hd3c417c_0
       - mkl_random=1.2.2=py37h51133e4_0
       - msgpack-python=1.0.2=py37hff7bd54_1
       - nbconvert=6.1.0=py37h06a4308_0
-      - ncurses=6.2=he6710b0_1
+      - ncurses=6.3=heee7806_1
       - netcdf4=1.5.7=py37h0a24e14_0
-      - notebook=6.4.0=py37h06a4308_0
-      - numba=0.53.1=py37ha9443f7_0
+      - notebook=6.4.5=py37h06a4308_0
+      - numba=0.54.1=py37h51133e4_0
       - numpy-base=1.20.3=py37h74d4b33_0
       - numpy=1.20.3=py37hf144106_0
-      - openjpeg=2.3.0=h05c96fa_1
-      - openssl=1.1.1k=h27cfd23_0
+      - openjpeg=2.4.0=h3ad879b_0
+      - openssl=1.1.1l=h7f8727e_0
       - pandas=1.2.5=py37h295c915_0
       - pandocfilters=1.4.3=py37h06a4308_1
       - pcre=8.45=h295c915_0
-      - pillow=8.3.1=py37h2c7a002_0
+      - pillow=8.4.0=py37h5aabda8_0
       - pip=21.2.2=py37h06a4308_0
-      - pixman=0.40.0=h7b6447c_0
+      - pixman=0.40.0=h7f8727e_1
       - poppler-data=0.4.10=h06a4308_0
       - poppler=0.81.0=h01f5e8b_2
       - postgresql=12.2=h553bfba_1
       - proj=6.2.1=haa6030c_0
       - psutil=5.8.0=py37h27cfd23_1
       - pyproj=2.6.1.post1=py37hb3025e9_1
-      - pyrsistent=0.17.3=py37h7b6447c_0
+      - pyrsistent=0.18.0=py37heee7806_0
       - pysocks=1.7.1=py37_1
       - python=3.7.11=h12debd9_0
-      - pyyaml=5.4.1=py37h27cfd23_1
-      - pyzmq=20.0.0=py37h2531618_1
+      - pyyaml=6.0=py37h7f8727e_1
+      - pyzmq=22.2.1=py37h295c915_1
       - readline=8.1=h27cfd23_0
       - rtree=0.9.7=py37h06a4308_1
-      - scikit-learn=0.24.2=py37ha9443f7_0
+      - scikit-learn=1.0.1=py37h51133e4_0
       - scipy=1.6.2=py37had2a1c9_1
-      - setuptools=52.0.0=py37h06a4308_0
-      - shapely=1.7.1=py37h98ec03d_0
+      - setuptools=58.0.4=py37h06a4308_0
+      - shapely=1.7.1=py37h1728cc4_0
       - sqlite=3.36.0=hc218d9a_0
-      - tbb=2020.3=hfd86e86_0
+      - tbb=2021.4.0=hd09550d_0
       - terminado=0.9.4=py37h06a4308_0
       - tiledb=2.2.9=hffe1d7a_0
-      - tk=8.6.10=hbc83047_0
+      - tk=8.6.11=h1ccaba5_0
       - tornado=6.1=py37h27cfd23_0
       - xerces-c=3.2.3=h780794e_0
       - xz=5.2.5=h7b6447c_0
@@ -708,57 +748,61 @@ env_specs:
       - brotli=1.0.9=hb1e8313_2
       - brotlipy=0.7.0=py37h9ed2024_1003
       - bzip2=1.0.8=h1de35cc_0
-      - ca-certificates=2021.7.5=hecd8cb5_1
+      - c-ares=1.17.1=h9ed2024_0
+      - ca-certificates=2021.10.26=hecd8cb5_2
       - cairo=1.16.0=h8023c5d_1
       - cartopy=0.18.0=py37hf1ba7ce_1
-      - certifi=2021.5.30=py37hecd8cb5_0
+      - certifi=2021.10.8=py37hecd8cb5_0
       - cffi=1.14.6=py37h2125817_0
       - cfitsio=3.470=hee0f690_6
       - cftime=1.5.0=py37he3068b8_0
-      - chardet=4.0.0=py37hecd8cb5_1003
       - cligj=0.7.2=py37hecd8cb5_0
-      - cryptography=3.4.7=py37h2fd3fbb_0
-      - curl=7.71.1=h7bc2e8c_2
+      - cryptography=35.0.0=py37h2fd3fbb_0
+      - curl=7.78.0=h7bc2e8c_0
       - cytoolz=0.11.0=py37haf1e3a3_0
       - datashape=0.5.4=py37hecd8cb5_1
-      - distributed=2021.7.2=py37hecd8cb5_0
+      - debugpy=1.4.1=py37h23ab428_0
+      - distributed=2021.10.0=py37hecd8cb5_0
       - expat=2.4.1=h23ab428_2
       - fiona=1.8.13.post1=py37h9c05f0f_0
       - fontconfig=2.13.1=ha9ee91d_0
-      - fonttools=4.25.0=pyhd3eb1b0_0
-      - freetype=2.10.4=ha233b18_0
+      - freetype=2.11.0=hd8bbffd_0
       - freexl=1.0.6=h9ed2024_0
       - gdal=3.0.2=py37ha6ec53f_1
       - geos=3.8.0=hb1e8313_0
       - geotiff=1.6.0=h02c1893_0
       - gettext=0.21.0=h7535e17_0
       - giflib=5.2.1=haf1e3a3_0
-      - glib=2.69.0=hdf23fa2_0
+      - glib=2.69.1=hdf23fa2_0
       - hdf4=4.2.13=h39711bb_2
       - hdf5=1.10.6=hdbbcd12_0
       - icu=58.2=h0a44026_3
-      - importlib-metadata=3.10.0=py37hecd8cb5_0
-      - intel-openmp=2021.3.0=hecd8cb5_3375
-      - ipython=7.22.0=py37h01d92e1_0
-      - jpeg=9b=he5867d9_2
+      - importlib-metadata=4.8.1=py37hecd8cb5_0
+      - intel-openmp=2021.4.0=hecd8cb5_3538
+      - ipykernel=6.4.1=py37hecd8cb5_1
+      - ipython=7.29.0=py37h01d92e1_0
+      - jedi=0.18.0=py37hecd8cb5_1
+      - jpeg=9d=h9ed2024_0
       - json-c=0.13.1=h3efe00b_0
-      - jupyter_core=4.7.1=py37hecd8cb5_0
+      - jupyter_core=4.8.1=py37hecd8cb5_0
       - kealib=1.4.14=h7bbef82_0
       - kiwisolver=1.3.1=py37h23ab428_0
       - krb5=1.19.2=hcd88c3b_0
       - lcms2=2.12=hf1fd2bf_0
       - libboost=1.73.0=hd4c2dcd_11
-      - libcurl=7.71.1=hb8e4fae_2
-      - libcxx=10.0.0=1
+      - libcurl=7.78.0=hb8e4fae_0
+      - libcxx=12.0.0=h2f01273_0
       - libdap4=3.19.1=h3d3e54a_0
-      - libedit=3.1.20210216=h9ed2024_1
+      - libedit=3.1.20210910=hca72f7f_0
+      - libev=4.33=h9ed2024_1
       - libffi=3.3=hb1e8313_2
       - libgdal=3.0.2=ha1444b2_1
       - libgfortran=3.0.1=h93005f0_2
       - libiconv=1.16=h1de35cc_0
       - libkml=1.3.0=h952ee91_5
-      - libllvm10=10.0.1=h76017ad_5
+      - libllvm11=11.1.0=h9b2ccf5_0
       - libnetcdf=4.6.1=hfd9a460_4
+      - libnghttp2=1.41.0=h7580e61_2
       - libpng=1.6.37=ha441bb4_0
       - libpq=12.2=h1b4eb34_1
       - libsodium=1.0.18=h1de35cc_0
@@ -767,57 +811,58 @@ env_specs:
       - libssh2=1.9.0=ha12b0ac_1
       - libtiff=4.2.0=h87d7836_0
       - libwebp-base=1.2.0=h9ed2024_0
+      - libwebp=1.2.0=hacca55c_0
       - libxml2=2.9.12=hcdb78fc_0
-      - llvm-openmp=10.0.0=h28b9765_0
-      - llvmlite=0.36.0=py37he4411ff_4
+      - llvm-openmp=12.0.0=h0dcd299_1
+      - llvmlite=0.37.0=py37he4411ff_1
       - locket=0.2.1=py37hecd8cb5_1
-      - lz4-c=1.9.3=h23ab428_0
+      - lz4-c=1.9.3=h23ab428_1
       - markdown=3.3.4=py37hecd8cb5_0
       - markupsafe=2.0.1=py37h9ed2024_0
-      - matplotlib-base=3.4.2=py37h8b3ea08_0
+      - matplotlib-base=3.4.3=py37h0a11d32_0
       - mistune=0.8.4=py37h1de35cc_0
       - mkl-service=2.4.0=py37h9ed2024_0
-      - mkl=2021.3.0=hecd8cb5_517
-      - mkl_fft=1.3.0=py37h4a7008c_2
+      - mkl=2021.4.0=hecd8cb5_637
+      - mkl_fft=1.3.1=py37h4ab4a9b_0
       - mkl_random=1.2.2=py37hb2f4e1b_0
       - msgpack-python=1.0.2=py37hf7b0b51_1
-      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37hecd8cb5_0
-      - ncurses=6.2=h0a44026_1
+      - ncurses=6.3=hca72f7f_1
       - netcdf4=1.5.7=py37h1695cb1_0
-      - notebook=6.4.0=py37hecd8cb5_0
-      - numba=0.53.0=py37hb2f4e1b_0
+      - notebook=6.4.5=py37hecd8cb5_0
+      - numba=0.54.1=py37hae1ba45_0
       - numpy-base=1.20.3=py37he0bd621_0
       - numpy=1.20.3=py37h4b4dc7a_0
-      - openjpeg=2.3.0=hb95cd4c_1
-      - openssl=1.1.1k=h9ed2024_0
+      - openjpeg=2.4.0=h66ea3da_0
+      - openssl=1.1.1l=h9ed2024_0
       - pandas=1.2.5=py37h23ab428_0
       - pandocfilters=1.4.3=py37hecd8cb5_1
       - pcre=8.45=h23ab428_0
-      - pillow=8.3.1=py37ha4cf6ea_0
+      - pillow=8.4.0=py37h98e4679_0
       - pip=21.2.2=py37hecd8cb5_0
-      - pixman=0.40.0=haf1e3a3_0
+      - pixman=0.40.0=h9ed2024_1
       - poppler-data=0.4.10=hecd8cb5_0
       - poppler=0.81.0=h031bf0f_2
       - postgresql=12.2=h1b4eb34_1
       - proj=6.2.1=hfd5b9e3_0
       - psutil=5.8.0=py37h9ed2024_1
       - pyproj=2.6.1.post1=py37hdfdfadc_1
-      - pyrsistent=0.17.3=py37haf1e3a3_0
+      - pyrsistent=0.18.0=py37hca72f7f_0
       - pysocks=1.7.1=py37hecd8cb5_0
       - python=3.7.11=h88f2d9e_0
-      - pyyaml=5.4.1=py37h9ed2024_1
-      - pyzmq=20.0.0=py37h23ab428_1
+      - pyyaml=6.0=py37hca72f7f_1
+      - pyzmq=22.2.1=py37h23ab428_1
       - readline=8.1=h9ed2024_0
       - rtree=0.9.7=py37hecd8cb5_1
-      - scikit-learn=0.24.2=py37hb2f4e1b_0
-      - scipy=1.6.2=py37hd5f7400_1
-      - setuptools=52.0.0=py37hecd8cb5_0
-      - shapely=1.7.1=py37hb435bde_0
+      - scikit-learn=1.0.1=py37hae1ba45_0
+      - scipy=1.7.1=py37h88652d9_2
+      - setuptools=58.0.4=py37hecd8cb5_0
+      - shapely=1.7.1=py37h9250791_0
       - sqlite=3.36.0=hce871da_0
+      - tbb=2021.4.0=haf03e11_0
       - terminado=0.9.4=py37hecd8cb5_0
       - tiledb=2.2.9=hdc16fd3_0
-      - tk=8.6.10=hb0a8c7a_0
+      - tk=8.6.11=h7bc2e8c_0
       - tornado=6.1=py37h9ed2024_0
       - xerces-c=3.2.3=h48eee30_0
       - xz=5.2.5=h1de35cc_0
@@ -835,24 +880,23 @@ env_specs:
       - brotli=1.0.9=ha925a31_2
       - brotlipy=0.7.0=py37h2bbff1b_1003
       - bzip2=1.0.8=he774522_0
-      - ca-certificates=2021.7.5=haa95532_1
+      - ca-certificates=2021.10.26=haa95532_2
       - cartopy=0.18.0=py37h80a4efb_1
-      - certifi=2021.5.30=py37haa95532_0
+      - certifi=2021.10.8=py37haa95532_0
       - cffi=1.14.6=py37h2bbff1b_0
       - cfitsio=3.470=he774522_6
       - cftime=1.5.0=py37h080aedc_0
-      - chardet=4.0.0=py37haa95532_1003
       - cligj=0.7.2=py37haa95532_0
       - colorama=0.4.4=pyhd3eb1b0_0
-      - cryptography=3.4.7=py37h71e12ea_0
-      - curl=7.71.1=h86230a5_2
+      - cryptography=35.0.0=py37h71e12ea_0
+      - curl=7.78.0=h86230a5_0
       - cytoolz=0.11.0=py37he774522_0
       - datashape=0.5.4=py37haa95532_1
-      - distributed=2021.7.2=py37haa95532_0
+      - debugpy=1.4.1=py37hd77b12b_0
+      - distributed=2021.10.0=py37haa95532_0
       - expat=2.4.1=h6c2663c_2
-      - fiona=1.8.13.post1=py37hd760492_0
-      - fonttools=4.25.0=pyhd3eb1b0_0
-      - freetype=2.10.4=hd328e21_0
+      - fiona=1.8.13.post1=py37h758c064_0
+      - freetype=2.11.0=ha860e81_0
       - freexl=1.0.6=h2bbff1b_0
       - gdal=3.0.2=py37hb978731_1
       - geos=3.8.0=h33f27b4_0
@@ -860,29 +904,31 @@ env_specs:
       - hdf4=4.2.13=h712560f_2
       - hdf5=1.10.6=h7ebc959_0
       - icc_rt=2019.0.0=h0cc432a_1
-      - importlib-metadata=3.10.0=py37haa95532_0
-      - intel-openmp=2021.3.0=haa95532_3372
-      - ipython=7.22.0=py37hd4e2768_0
-      - jpeg=9b=hb83a4c4_2
-      - jupyter_core=4.7.1=py37haa95532_0
+      - importlib-metadata=4.8.1=py37haa95532_0
+      - intel-openmp=2021.4.0=haa95532_3556
+      - ipykernel=6.4.1=py37haa95532_1
+      - ipython=7.29.0=py37hd4e2768_0
+      - jedi=0.18.0=py37haa95532_1
+      - jpeg=9d=h2bbff1b_0
+      - jupyter_core=4.8.1=py37haa95532_0
       - kealib=1.4.14=hde4a422_0
       - kiwisolver=1.3.1=py37hd77b12b_0
       - krb5=1.19.2=h5b6d351_0
-      - libcurl=7.71.1=h86230a5_2
+      - libcurl=7.78.0=h86230a5_0
       - libgdal=3.0.2=ha1b3edf_1
       - libiconv=1.15=h1df5818_7
       - libnetcdf=4.6.1=hf59b723_4
       - libpng=1.6.37=h2a8f88b_0
       - libpq=12.2=hb652d5d_1
-      - libsodium=1.0.18=h62dcd97_0
       - libspatialindex=1.9.3=h6c2663c_0
       - libspatialite=4.3.0a=h7ffb84d_0
       - libssh2=1.9.0=h7a1dbc1_1
       - libtiff=4.2.0=hd0e1b90_0
+      - libwebp=1.2.0=h2bbff1b_0
       - libxml2=2.9.12=h0ad7f3c_0
-      - llvmlite=0.36.0=py37h34b8924_4
+      - llvmlite=0.37.0=py37h23ce68f_1
       - locket=0.2.1=py37haa95532_1
-      - lz4-c=1.9.3=h2bbff1b_0
+      - lz4-c=1.9.3=h2bbff1b_1
       - m2w64-expat=2.1.1=2
       - m2w64-gcc-libgfortran=5.3.0=6
       - m2w64-gcc-libs-core=5.3.0=7
@@ -894,56 +940,55 @@ env_specs:
       - m2w64-xz=5.2.2=2
       - markdown=3.3.4=py37haa95532_0
       - markupsafe=2.0.1=py37h2bbff1b_0
-      - matplotlib-base=3.4.2=py37h49ac443_0
+      - matplotlib-base=3.4.3=py37h49ac443_0
       - mistune=0.8.4=py37hfa6e2cd_1001
       - mkl-service=2.4.0=py37h2bbff1b_0
-      - mkl=2021.3.0=haa95532_524
-      - mkl_fft=1.3.0=py37h277e83a_2
+      - mkl=2021.4.0=haa95532_640
+      - mkl_fft=1.3.1=py37h277e83a_0
       - mkl_random=1.2.2=py37hf11a4ad_0
       - msgpack-python=1.0.2=py37h59b6b97_1
       - msys2-conda-epoch=20160418=1
-      - munkres=1.1.4=py_0
       - nbconvert=6.1.0=py37haa95532_0
       - netcdf4=1.5.7=py37hb33177a_0
-      - notebook=6.4.0=py37haa95532_0
-      - numba=0.53.0=py37hf11a4ad_0
+      - notebook=6.4.5=py37haa95532_0
+      - numba=0.54.1=py37hf11a4ad_0
       - numpy-base=1.20.3=py37hc2deb75_0
       - numpy=1.20.3=py37ha4e8547_0
-      - openjpeg=2.3.0=h5ec785f_1
-      - openssl=1.1.1k=h2bbff1b_0
+      - openjpeg=2.4.0=h4fc8c34_0
+      - openssl=1.1.1l=h2bbff1b_0
       - pandas=1.2.5=py37hd77b12b_0
       - pandocfilters=1.4.3=py37haa95532_1
-      - pillow=8.3.1=py37h4fa10fc_0
-      - pip=21.2.2=py37haa95532_0
+      - pillow=8.4.0=py37hd45dc43_0
+      - pip=21.2.4=py37haa95532_0
       - postgresql=12.2=hb652d5d_1
       - proj=6.2.1=h9f7ef89_0
       - psutil=5.8.0=py37h2bbff1b_1
       - pyproj=2.6.1.post1=py37h593ac45_1
-      - pyrsistent=0.17.3=py37he774522_0
+      - pyrsistent=0.18.0=py37h196d8e1_0
       - pysocks=1.7.1=py37_1
       - python=3.7.11=h6244533_0
       - pywin32=228=py37hbaba5e8_1
       - pywinpty=0.5.7=py37_0
-      - pyyaml=5.4.1=py37h2bbff1b_1
-      - pyzmq=20.0.0=py37hd77b12b_1
+      - pyyaml=6.0=py37h2bbff1b_1
+      - pyzmq=22.2.1=py37hd77b12b_1
       - rtree=0.9.7=py37h2eaa2aa_1
-      - scikit-learn=0.24.2=py37hf11a4ad_1
-      - scipy=1.6.2=py37h66253e8_1
-      - setuptools=52.0.0=py37haa95532_0
-      - shapely=1.7.1=py37h210f175_0
+      - scikit-learn=1.0.1=py37hf11a4ad_0
+      - scipy=1.7.1=py37hbe87c03_2
+      - setuptools=58.0.4=py37haa95532_0
+      - shapely=1.7.1=py37h06580b3_0
       - sqlite=3.36.0=h2bbff1b_0
+      - tbb=2021.4.0=h59b6b97_0
       - terminado=0.9.4=py37haa95532_0
       - tiledb=2.2.9=hf7ce2e6_0
-      - tk=8.6.10=he774522_0
+      - tk=8.6.11=h2bbff1b_0
       - tornado=6.1=py37h2bbff1b_0
       - vc=14.2=h21ff451_1
       - vs2015_runtime=14.27.29016=h5e58377_2
       - win_inet_pton=1.1.0=py37haa95532_0
-      - wincertstore=0.2=py37_0
+      - wincertstore=0.2=py37haa95532_2
       - winpty=0.4.3=4
       - xerces-c=3.2.3=ha925a31_0
       - xz=5.2.5=h62dcd97_0
       - yaml=0.2.5=he774522_0
-      - zeromq=4.3.3=ha925a31_3
       - zlib=1.2.11=h62dcd97_4
       - zstd=1.4.9=h19a0ad4_0

--- a/bay_trimesh/anaconda-project.yml
+++ b/bay_trimesh/anaconda-project.yml
@@ -50,7 +50,7 @@ env_specs:
     packages: &testpkgs
     - nbsmoke=0.2.8
     - pytest=4.4.1
-  dependencies: *testpkgs
+    dependencies: *testpkgs
 platforms:
 - linux-64
 - osx-64


### PR DESCRIPTION
The `dependencies` key in the `test` env was unindented by one extra one-level and the lock file needed updating. I've run the notebook to make sure everything still works.