### PR TITLE
Fixed handling of defaults and nodefaults in channel lists

### DIFF
--- a/attractors/anaconda-project.yml
+++ b/attractors/anaconda-project.yml
@@ -9,6 +9,7 @@ labels:
 
 channels:
 - pyviz
+- defaults
 
 user_fields: [labels, skip, maintainers]
 

--- a/bay_trimesh/anaconda-project.yml
+++ b/bay_trimesh/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/boids/anaconda-project.yml
+++ b/boids/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
   - python=3.7

--- a/carbon_flux/anaconda-project.yml
+++ b/carbon_flux/anaconda-project.yml
@@ -11,7 +11,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [pyviz]
+channels: [pyviz, defaults]
 
 packages: &pkgs
 - python=3.7

--- a/census/anaconda-project.yml
+++ b/census/anaconda-project.yml
@@ -11,7 +11,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [pyviz,conda-forge]
+channels: [pyviz,conda-forge,defaults]
 
 packages: &pkgs
 - python=3.7

--- a/datashader_dashboard/anaconda-project.yml
+++ b/datashader_dashboard/anaconda-project.yml
@@ -15,7 +15,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - conda-forge
-- nodefaults
+- defaults  # Previously nodefaults attempt
 
 packages: &pkgs
 - python=3.7

--- a/euler/anaconda-project.yml
+++ b/euler/anaconda-project.yml
@@ -10,7 +10,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.6

--- a/gapminders/anaconda-project.yml
+++ b/gapminders/anaconda-project.yml
@@ -13,7 +13,7 @@ user_fields: [labels, skip, maintainers, user_fields, user_fields, user_fields, 
 
 channels:
 - conda-forge
-- nodefaults
+- defaults  # Previously nodefaults attempt
 
 packages: &pkgs
 - python=3.7

--- a/genetic_algorithm/anaconda-project.yml
+++ b/genetic_algorithm/anaconda-project.yml
@@ -12,7 +12,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - conda-forge
-- nodefaults
+- defaults  # Previously nodefaults attempt
 
 packages: &pkgs
 - python=3.7

--- a/gerrymandering/anaconda-project.yml
+++ b/gerrymandering/anaconda-project.yml
@@ -8,7 +8,7 @@ labels:
 - datashader
 - geoviews
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/glaciers/anaconda-project.yml
+++ b/glaciers/anaconda-project.yml
@@ -12,6 +12,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - pyviz
+- defaults
 
 packages: &pkgs
 - python=3.7

--- a/goldbach_comet/anaconda-project.yml
+++ b/goldbach_comet/anaconda-project.yml
@@ -11,6 +11,7 @@ labels:
 channels:
   - pyviz
   - conda-forge
+  - defaults
 
 user_fields: [labels, created, maintainers]
 

--- a/gull_tracking/anaconda-project.yml
+++ b/gull_tracking/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/heat_and_trees/anaconda-project.yml
+++ b/heat_and_trees/anaconda-project.yml
@@ -14,7 +14,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/hipster_dynamics/anaconda-project.yml
+++ b/hipster_dynamics/anaconda-project.yml
@@ -12,7 +12,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/iex_trading/anaconda-project.yml
+++ b/iex_trading/anaconda-project.yml
@@ -15,7 +15,7 @@ skip:
 - IEX_to_CSV.ipynb
 
 user_fields: [labels, skip, maintainers]
-channels: [pyviz/label/dev]
+channels: [pyviz/label/dev, defaults]
 
 packages: &pkgs
 - python=3.7

--- a/landsat/anaconda-project.yml
+++ b/landsat/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [pyviz]
+channels: [pyviz, defaults]
 
 packages: &pkgs
 - python=3.7

--- a/landsat_clustering/anaconda-project.yml
+++ b/landsat_clustering/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [conda-forge]
+channels: [conda-forge,defaults]
 
 packages: &pkgs
 - python=3.7

--- a/landuse_classification/anaconda-project.yml
+++ b/landuse_classification/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/lsystems/anaconda-project.yml
+++ b/lsystems/anaconda-project.yml
@@ -8,7 +8,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/ml_annotators/anaconda-project.yml
+++ b/ml_annotators/anaconda-project.yml
@@ -11,6 +11,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - pyviz/label/dev
+- defaults
 
 packages: &pkgs
 - python=3.7

--- a/network_packets/anaconda-project.yml
+++ b/network_packets/anaconda-project.yml
@@ -10,7 +10,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [conda-forge]
+channels: [conda-forge, defaults]
 
 packages: &pkgs
 - python=3.7

--- a/nyc_taxi/anaconda-project.yml
+++ b/nyc_taxi/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/opensky/anaconda-project.yml
+++ b/opensky/anaconda-project.yml
@@ -7,7 +7,7 @@ maintainers:
 labels:
 - datashader
 
-channels: []
+channels: [defaults]
 
 user_fields: [labels, created, maintainers]
 

--- a/osm/anaconda-project.yml
+++ b/osm/anaconda-project.yml
@@ -10,6 +10,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - conda-forge
+- defaults
 
 packages: &pkgs
 - python=3.7

--- a/particle_swarms/anaconda-project.yml
+++ b/particle_swarms/anaconda-project.yml
@@ -12,7 +12,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - conda-forge
-- nodefaults
+- defaults # Previously nodefaults attempt
 
 packages: &pkgs
 - python=3.7

--- a/penguin_crossfilter/anaconda-project.yml
+++ b/penguin_crossfilter/anaconda-project.yml
@@ -12,6 +12,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - pyviz
+- defaults
 
 packages: &pkgs
 - python=3.8

--- a/portfolio_optimizer/anaconda-project.yml
+++ b/portfolio_optimizer/anaconda-project.yml
@@ -10,7 +10,7 @@ labels:
 
 user_fields: [labels, skip, maintainers, user_fields]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.8

--- a/seattle_lidar/anaconda-project.yml
+++ b/seattle_lidar/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [conda-forge, pyviz,nodefaults]
+channels: [conda-forge, pyviz,defaults] # Previously nodefaults attempt
 
 packages: &pkgs
   - python=3.7

--- a/ship_traffic/anaconda-project.yml
+++ b/ship_traffic/anaconda-project.yml
@@ -12,6 +12,7 @@ user_fields: [labels, skip, maintainers, user_fields]
 channels:
 - pyviz
 - conda-forge
+- defaults
 
 packages: &pkgs
 - python=3.7 

--- a/square_limit/anaconda-project.yml
+++ b/square_limit/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/sri_model/anaconda-project.yml
+++ b/sri_model/anaconda-project.yml
@@ -10,7 +10,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/template/anaconda-project.yml
+++ b/template/anaconda-project.yml
@@ -9,6 +9,7 @@ labels:
 
 channels:
   - pyviz
+  - defaults
 
 packages: &pkgs
   - python=3.6

--- a/uk_researchers/anaconda-project.yml
+++ b/uk_researchers/anaconda-project.yml
@@ -9,7 +9,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: []
+channels: [defaults]
 
 packages: &pkgs
 - python=3.7

--- a/voila_gpx_viewer/anaconda-project.yml
+++ b/voila_gpx_viewer/anaconda-project.yml
@@ -13,6 +13,7 @@ user_fields: [labels, skip, maintainers]
 
 channels:
 - conda-forge
+- defaults
 
 packages: &pkgs
 - python=3.7

--- a/walker_lake/anaconda-project.yml
+++ b/walker_lake/anaconda-project.yml
@@ -10,7 +10,7 @@ labels:
 
 user_fields: [labels, skip, maintainers]
 
-channels: [pyviz,conda-forge]
+channels: [pyviz,conda-forge,defaults]
 
 packages: &pkgs
   - python=3.7


### PR DESCRIPTION

Fix for the issue described in  https://github.com/Anaconda-Platform/anaconda-project/pull/387 and https://github.com/Anaconda-Platform/anaconda-project/issues/388.

In short:

* The `defaults` channel was implicitly picked up from the `.condarc`
* `nodefaults` was ignored by anaconda-project (though it is respected by conda itself)
* The latest anaconda-project version now (correctly) ignores the `~/.condarc` which has implications for backwards compatibility.

This PR attempts to fix this issue as follows:

* Make `defaults` explicit everywhere by appending it to the channel list if it is not stated. This should be backwards and forwards compatible with anaconda-project.
* Remove any instances of` nodefaults`, making sure `defaults` appears at the end of the list and noting that the *intention* was to avoid using defaults in a comment.

I *believe* this should fix compatibility but this PR has the possibility of breaking lots of things so please make sure you agree with this strategy @jbednar @maximlt !