### PR TITLE
Allow to skip a project build

### DIFF
--- a/.github/actions/build_one/action.yml
+++ b/.github/actions/build_one/action.yml
@@ -24,13 +24,11 @@ runs:
     - name: conda setup
       shell: bash -l {0} 
       run: |
-        eval "$(conda shell.bash hook)"
         conda install -c pyviz "pyctdev>=0.5"
         doit ecosystem_setup
     - name: build project
       shell: bash -l {0} 
       run: |
-        eval "$(conda shell.bash hook)"
         DIR=${{ inputs.project }}
         doit archive_project --name $DIR
         anaconda-project prepare --directory $DIR

--- a/.github/actions/build_one/action.yml
+++ b/.github/actions/build_one/action.yml
@@ -31,11 +31,26 @@ runs:
       run: |
         DIR=${{ inputs.project }}
         doit archive_project --name $DIR
-        anaconda-project prepare --directory $DIR
-        source activate $DIR/envs/default && pip install pyctdev
-        conda install -y "conda-forge::myst-nb"  "pyviz/label/dev::nbsite==0.7.0a7" holoviews sphinx_pyviz_theme selenium
-        conda install 'conda-forge::lxml'
-        doit build_project --name $DIR
+        # Last line to get the output of the action only
+        SKIP=$(doit skip_build --name $DIR | tail -n 1)
+
+        if [[ "$SKIP" == "skip" ]]
+        then
+            echo "Project set to skip project build."
+            doit move_thumbnails --name $DIR
+        elif [[ "$SKIP" == "noskip" ]]
+        then
+            echo "Project build..."
+            anaconda-project prepare --directory $DIR
+            source activate $DIR/envs/default && pip install pyctdev
+            conda install -y "conda-forge::myst-nb"  "pyviz/label/dev::nbsite==0.7.0a7" holoviews sphinx_pyviz_theme selenium
+            conda install 'conda-forge::lxml'
+            doit move_thumbnails --name $DIR
+            doit build_project --name $DIR
+        else
+            echo "Unexpected output from task_skip_build"
+            exit 1
+        fi
     - name: deploy project
       shell: bash -l {0} 
       # Deploy only when the target is 'evaluted' on workflow_dispatch, or on push

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
             echo "The workflow can only run on push or workflow_dispatch events."
             exit 1
           fi
-          echo "::set-output name=DIR::$DIR"
+          echo "DIR=$DIR" >> $GITHUB_OUTPUT
           if [ -e ./$DIR ]; then
             PROJECT_EXISTS=true
           else
@@ -58,7 +58,7 @@ jobs:
             exit 1
           fi
           echo "Building the project $DIR"
-          echo "::set-output name=PROJECT_EXISTS::$PROJECT_EXISTS"
+          echo "PROJECT_EXISTS=$PROJECT_EXISTS" >> $GITHUB_OUTPUT
       - name: Build project ${{ matrix.project }}
         if: steps.vars.outputs.PROJECT_EXISTS == 'true'
         uses: ./.github/actions/build_one

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,6 @@ jobs:
           doit env_create ${{ env.CHANS_DEV}} --python=3.7
       - name: doit develop_install
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           conda install -y -c pyviz/label/dev "nbsite>=0.6.5" sphinx_pyviz_theme lxml pyyaml holoviews nomkl "parso>=0.8,<0.9"
       - name: Wait for build to succeed
@@ -45,7 +44,6 @@ jobs:
           git checkout evaluated -- ./doc
       - name: build docs
         run: |
-          eval "$(conda shell.bash hook)"
           conda activate test-environment
           doit build_website
           doit index_redirects

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           MSG="${{ github.event.head_commit.message }}"
           MSG="${MSG##*test:}"
-          echo "::set-output name=DIR::${MSG%]*}"
+          echo "DIR=${MSG%]*" >> $GITHUB_OUTPUT
       - name: run test
         run: |
           eval "$(conda shell.bash hook)"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,11 @@ jobs:
           miniconda-version: "latest"
       - name: conda setup
         run: |
-          eval "$(conda shell.bash hook)"
           conda config --set always_yes True
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
       - name: doit test_project
         run: |
-          eval "$(conda shell.bash hook)"
           for DIR in *; do
             if [ -d "${DIR}" ]; then
               echo "checking for changes in $DIR"
@@ -65,7 +63,6 @@ jobs:
         run: git fetch --prune --tags --unshallow
       - name: conda setup
         run: |
-          eval "$(conda shell.bash hook)"
           conda config --set always_yes True
           conda install -c pyviz "pyctdev>=0.5"
           doit ecosystem_setup
@@ -77,7 +74,6 @@ jobs:
           echo "DIR=${MSG%]*" >> $GITHUB_OUTPUT
       - name: run test
         run: |
-          eval "$(conda shell.bash hook)"
           doit small_data_setup --name ${{ steps.vars.outputs.DIR }}
           doit test_project --name ${{ steps.vars.outputs.DIR }}
           doit small_data_cleanup --name ${{ steps.vars.outputs.DIR }}

--- a/attractors/anaconda-project.yml
+++ b/attractors/anaconda-project.yml
@@ -1,16 +1,17 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: attractors
 description: Calculate and plot two-dimensional attractors of a variety of types
-maintainers:
-- jbednar
-labels:
-- datashader
-- panel
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - panel
 
 channels:
 - pyviz
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 packages: &pkgs
 - python=3.7

--- a/bay_trimesh/anaconda-project.yml
+++ b/bay_trimesh/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: bay_trimesh
 description: Visualizing water depth into the Chesapeake and Delaware Bays
-maintainers:
-- philippjfr
-labels:
-- geoviews
-- datashader
+examples_config:
+  maintainers:
+  - philippjfr
+  labels:
+  - geoviews
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/boids/anaconda-project.yml
+++ b/boids/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: boids
 description: Boids models of swarm intelligence using HoloViews
-created: 2015-01-01
-maintainers:
-  - jlstevens
-labels:
-  - holoviews
+examples_config:
+  created: 2015-01-01
+  maintainers:
+    - jlstevens
+  labels:
+    - holoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/carbon_flux/anaconda-project.yml
+++ b/carbon_flux/anaconda-project.yml
@@ -2,14 +2,15 @@
 name: carbon_flux
 description: Analysis of NASA Goddard/University of Alabama carbon monitoring project
   NEE Data Fusion
-maintainers:
-- jbednar
-- jlstevens
-labels:
-- datashader
-- geoviews
+examples_config:
+  maintainers:
+  - jbednar
+  - jlstevens
+  labels:
+  - datashader
+  - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [pyviz]
 

--- a/census/anaconda-project.yml
+++ b/census/anaconda-project.yml
@@ -3,13 +3,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: census
 description: Visualize 2010 Census demographic data
-maintainers:
-- jbednar
-labels:
-- datashader
-- geoviews
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [pyviz,conda-forge]
 

--- a/datashader_dashboard/anaconda-project.yml
+++ b/datashader_dashboard/anaconda-project.yml
@@ -2,16 +2,17 @@
 name: datashader_dashboard
 description: Interactive dashboard for making Datashader plots from any dataset that
   has latitude and longitude
-created: 2018-11-12
-maintainers:
-- jsignell
-- jbednar
-labels:
-- channel_conda-forge
-- datashader
-- panel
+examples_config:
+  created: 2018-11-12
+  maintainers:
+  - jsignell
+  - jbednar
+  labels:
+  - channel_conda-forge
+  - datashader
+  - panel
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - conda-forge

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,15 +45,20 @@ def gallery_spec(name):
             f'https://{url_name}.pyviz.demo.anaconda.com',
             f'https://{url_name}-notebooks.pyviz.demo.anaconda.com']
     description = spec['description']
-    orphans = spec.get('orphans', [])
+    # Examples specific spec.
+    examples_config = spec.get('examples_config', {})
+    orphans = examples_config.get('orphans', [])
+    labels = examples_config.get('labels', [])
+    skip = examples_config.get('skip', False)
     if 'index.ipynb' in os.listdir(os.path.join('..', name)):
         description = f'`{description} <{name}/index.ipynb>`_'
         orphans.append('index.ipynb')
+
     return {
         'path': name,
         'description': description,
-        'labels': spec.get('labels', []),
-        'skip': spec.get('skip', False),
+        'labels': labels,
+        'skip': skip,
         'orphans': orphans,
         'deployment_urls': deployment_urls,
     }

--- a/doc/make_project.rst
+++ b/doc/make_project.rst
@@ -40,7 +40,7 @@ for these particular projects.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Copy template/.projectignore and  template/anaconda-project.yml to your own project,
-then just replace NAME, DESC, MAINTAINERS, CREATED, LABELS and add the dependencies
+then just replace NAME, DESCRIPTION, MAINTAINERS, CREATED, LABELS and add the dependencies
 from step 2.
 
 **Labels**
@@ -121,6 +121,12 @@ If you'd like notebooks to be skipped entirely when building the website, use th
 
    skip:
       - data_prep.ipynb
+
+If you'd like to skip building a project, use the ``skip_project_build`` option (`false` by default):
+
+.. code:: yaml
+
+   skip_project_build: true
 
 4. Make sure it works
 ~~~~~~~~~~~~~~~~~~~~~
@@ -246,43 +252,8 @@ Building a project locally
 
 In a minority of cases, the project takes so long to build or the data are
 so large, that it isn't feasible to build the website version of the project
-on Travis CI. In those cases, the project maintainer is responsible for
-running the build commands locally and committing the results to the
-``evaluated`` branch. To build the project follow these steps:
-
-::
-
-   export DIR=bears
-   doit archive_project --name $DIR
-   anaconda-project prepare --directory $DIR
-   conda activate $DIR/envs/default && pip install pyctdev
-   conda install -y -c pyviz/label/dev nbsite sphinx_pyviz_theme selenium phantomjs lxml
-   doit build_project --name $DIR
-
-You should end up with a new directory in the doc dir with the same name
-as your project. The structure of that directory should be as follows:
-
-::
-
-   doc/bears
-   ├── bears.ipynb
-   ├── bears.rst
-   ├── bears.zip
-   └── thumbnails
-      └── bears.png
-
-Commit only that doc/bears directory to the ``evaluated`` branch. The easiest way to
-do that is by moving it to a temporary directory, checking out the ``evaluated``
-branch and then moving it back:
-
-::
-
-   mv ./doc/$DIR ./tmp
-   git checkout evaluated
-   git pull
-   if [ -e  ./doc/$DIR ]; then rm -rf ./doc/$DIR; fi
-   mkdir ./doc/$DIR
-   mv ./tmp/* ./doc/$DIR
-   git add ./doc/$DIR
-   git commit -m "adding $DIR"
-   git push
+on the CI. In those cases, the project maintainer is responsible for
+running the build commands locally and submitting the evaluated notebook
+in the Pull Request. You **must** set the special option
+``skip_project_build`` to `true` to let the system know that it should
+not try to build the project.

--- a/doc/make_project.rst
+++ b/doc/make_project.rst
@@ -3,7 +3,7 @@ Making a new project
 
 Once you have a notebook that you think it is ready to be its own
 project you can follow these steps to get it set up. For the examples
-I’ll use an example project named “bears”:
+I'll use an example project named “bears”:
 
 1. Move the notebook into a new directory with same name
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,7 +22,7 @@ order.
 2. Start specifying the package dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It can take a while to be sure you’ve captured every dependency, but I
+It can take a while to be sure you've captured every dependency, but I
 usually start by using nbrr (``conda install -c conda-forge nbrr``)
 which reads the notebooks and looks for dependencies:
 
@@ -33,7 +33,7 @@ which reads the notebooks and looks for dependencies:
 **NOTE:** We tend to add ``nomkl`` to the list of dependencies to speed
 up environment build times. But there is no rule that you must do this.
 MKL is used for better runtime performance in numpy operations, but since we
-use Numba for most of the internal computations it’s not as important
+use Numba for most of the internal computations it's not as important
 for these particular projects.
 
 3. Create the anaconda-project file
@@ -145,7 +145,7 @@ Unless your data is small enough that it can be processed on every
 continuous-integration build, you should make a much smaller version
 of the data and put it in
 ``test_data/bears``. This step allows automated tests to be run in a
-practical way, exercising all of the example’s functionality but on a
+practical way, exercising all of the example's functionality but on a
 feasible subset of the data involved.
 
 6. If using intake (optional)

--- a/dodo.py
+++ b/dodo.py
@@ -1,5 +1,6 @@
 import os
 import glob
+# TODO: distutils is deprecated isn't it?
 from distutils.dir_util import copy_tree
 import filecmp
 import shutil
@@ -182,6 +183,25 @@ def task_small_data_cleanup():
 
     return {'actions': [remove_test_data], 'params': [name_param]}
 
+def task_skip_build():
+    """Print 'evaluated' if the project has been configured with skip_doc_evaluation"""
+
+    def skip_build(root='', name='all'):
+        from yaml import safe_load, safe_dump
+
+        path = os.path.join(name, 'anaconda-project.yml')
+        with open(path, 'r') as f:
+            spec = safe_load(f)
+
+        skip_doc_evaluation = spec.get('examples_config', {}).get('skip_doc_evaluation', False)
+
+        if skip_doc_evaluation:
+            print("skip")
+        else:
+            print("noskip")
+
+    return {'actions': [skip_build], 'params': [name_param]}
+
 def task_archive_project():
     """Archive project with given name, assumes anaconda-project is in env"""
 
@@ -229,23 +249,28 @@ def task_archive_project():
 
     return {'actions': [archive_project], 'params': [name_param]}
 
+def move_thumbnails(name):
+    from shutil import copyfile
+    src_dir = os.path.join(name, 'thumbnails')
+    dst_dir = os.path.join('doc', name, 'thumbnails')
+    if os.path.exists(src_dir):
+        if not os.path.exists(dst_dir):
+            os.makedirs(dst_dir)
+        for item in os.listdir(src_dir):
+            src = os.path.join(src_dir, item)
+            dst = os.path.join(dst_dir, item)
+            copyfile(src, dst)
+
+def task_move_thumbnails():
+    """Move the thumbnails from the project dir to the doc dir"""
+    return {'actions': [
+        move_thumbnails,
+    ], 'params': [name_param]}
+
 def task_build_project():
     """Build project with given name, assumes you are in an environment with required dependencies"""
 
-    def move_thumbnails(name):
-        from shutil import copyfile
-        src_dir = os.path.join(name, 'thumbnails')
-        dst_dir = os.path.join('doc', name, 'thumbnails')
-        if os.path.exists(src_dir):
-            if not os.path.exists(dst_dir):
-                os.makedirs(dst_dir)
-            for item in os.listdir(src_dir):
-                src = os.path.join(src_dir, item)
-                dst = os.path.join(dst_dir, item)
-                copyfile(src, dst)
-
     return {'actions': [
-        move_thumbnails,
         "DIR=%(name)s nbsite build --examples .",
     ], 'params': [name_param]}
 
@@ -340,6 +365,7 @@ def task_changes_in_dir():
             return False
         with open(filepath) as f:
             paths = f.readlines()
+        # TODO: what if the changed file is in a nested dir? The dir should be the root one
         dirs = list(set(os.path.dirname(path) for path in paths))
         return name in dirs
 

--- a/dodo.py
+++ b/dodo.py
@@ -184,7 +184,7 @@ def task_small_data_cleanup():
     return {'actions': [remove_test_data], 'params': [name_param]}
 
 def task_skip_build():
-    """Print 'evaluated' if the project has been configured with skip_doc_evaluation"""
+    """Print 'evaluated' if the project has been configured with skip_project_build"""
 
     def skip_build(root='', name='all'):
         from yaml import safe_load, safe_dump
@@ -193,9 +193,9 @@ def task_skip_build():
         with open(path, 'r') as f:
             spec = safe_load(f)
 
-        skip_doc_evaluation = spec.get('examples_config', {}).get('skip_doc_evaluation', False)
+        skip_project_build = spec.get('examples_config', {}).get('skip_project_build', False)
 
-        if skip_doc_evaluation:
+        if skip_project_build:
             print("skip")
         else:
             print("noskip")

--- a/dodo.py
+++ b/dodo.py
@@ -204,12 +204,8 @@ def task_archive_project():
             with open(path, 'r') as f:
                 spec = safe_load(f)
 
-            # special fields that anaconda-project doesn't know about
-            spec.pop('labels', '')
-            spec.pop('maintainers', '')
-            spec.pop('created', '')
-            spec.pop('skip', '')
-            spec.pop('orphans', '')
+            # special field that anaconda-project doesn't know about
+            spec.pop('examples_config', '')
             spec.pop('user_fields', '')
 
             # commands and envs that users don't need

--- a/euler/anaconda-project.yml
+++ b/euler/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: euler
 description: Panel dashboard illustrating Euler's Method
-created: 2018-11-16
-maintainers:
-- jbednar
-labels:
-- panel
-- holoviews
+examples_config:
+  created: 2018-11-16
+  maintainers:
+  - jbednar
+  labels:
+  - panel
+  - holoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/exoplanets/anaconda-project.yml
+++ b/exoplanets/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: exoplanets
 description: Map of confirmed and candidate exoplanets by discovery date
-created: 2021-06-17
-maintainers:
-  - ablythed
-labels:
-  - hvplot
-  - panel
+examples_config:
+  created: 2021-06-17
+  maintainers:
+    - ablythed
+  labels:
+    - hvplot
+    - panel
 
-user_fields: [labels, skip, maintainers, created]
+user_fields: [examples_config]
 
 channels: [defaults, pyviz/label/dev]
 

--- a/gapminders/anaconda-project.yml
+++ b/gapminders/anaconda-project.yml
@@ -2,14 +2,14 @@
 name: gapminders
 description: Using four different plotting libraries for the Hans Rosling gapminder
   example
-maintainers:
-- philippjfr
-labels:
-- panel
-- channel_conda-forge
+examples_config:
+  maintainers:
+  - philippjfr
+  labels:
+  - panel
+  - channel_conda-forge
 
-user_fields: [labels, skip, maintainers, user_fields, user_fields, user_fields, user_fields,
-  user_fields]
+user_fields: [examples_config]
 
 channels:
 - conda-forge

--- a/genetic_algorithm/anaconda-project.yml
+++ b/genetic_algorithm/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: genetic_algorithm
 description: Interactive dashboard for Genetic Algorithm
-created: 2020-07-22
-maintainers:
-- scottire
-labels:
-- holoviews
-- panel
+examples_config:
+  created: 2020-07-22
+  maintainers:
+  - scottire
+  labels:
+  - holoviews
+  - panel
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - conda-forge

--- a/gerrymandering/anaconda-project.yml
+++ b/gerrymandering/anaconda-project.yml
@@ -1,12 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: gerrymandering
 description: Combine data of very different types to show gerrymandering
-maintainers:
-- philippjfr
-- jbednar
-labels:
-- datashader
-- geoviews
+examples_config:
+  maintainers:
+  - philippjfr
+  - jbednar
+  labels:
+  - datashader
+  - geoviews
+
+user_fields: [examples_config]
 
 channels: []
 

--- a/glaciers/anaconda-project.yml
+++ b/glaciers/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: glaciers
 description: Glaciers explorer using Datashader and Panel
-maintainers:
-- philippjfr
-labels:
-- panel
-- geoviews
-- datashader
+examples_config:
+  maintainers:
+  - philippjfr
+  labels:
+  - panel
+  - geoviews
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - pyviz

--- a/goldbach_comet/anaconda-project.yml
+++ b/goldbach_comet/anaconda-project.yml
@@ -1,18 +1,19 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: Goldbach's comet
 description: Evaluating Goldbach function with Numba and plotting it with Datashader
-created: 2021-08-24
-maintainers:
-labels:
-  - datashader
-  - matplotlib
-  - channel_conda-forge
+examples_config:
+  created: 2021-08-24
+  maintainers:
+  labels:
+    - datashader
+    - matplotlib
+    - channel_conda-forge
 
 channels:
   - pyviz
   - conda-forge
 
-user_fields: [labels, created, maintainers]
+user_fields: [examples_config]
 
 packages: &pkgs
   - python=3.6

--- a/gull_tracking/anaconda-project.yml
+++ b/gull_tracking/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: gull_tracking
 description: Visualizing GPS tracking for herring gulls in Belgium
-maintainers:
-- jbednar
-labels:
-- datashader
-- holoviews
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - holoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/heat_and_trees/anaconda-project.yml
+++ b/heat_and_trees/anaconda-project.yml
@@ -4,15 +4,16 @@ description: |
   Analysis of how trees affect heat distribution in urban areas. Based on
   `a blog post <http://urbanspatialanalysis.com/urban-heat-islands-street-trees-in-philadelphia/>`_
   by Ken Steif.
-created: 2018-10-01
-maintainers:
-- jsignell
-labels:
-- hvplot
-- geoviews
-- datashader
+examples_config:
+  created: 2018-10-01
+  maintainers:
+  - jsignell
+  labels:
+  - hvplot
+  - geoviews
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/hipster_dynamics/anaconda-project.yml
+++ b/hipster_dynamics/anaconda-project.yml
@@ -4,13 +4,14 @@ description: |
   The Hipster Effect - An IPython Interactive Exploration. Adapted from
   the `original notebook <http://jakevdp.github.io/blog/2014/11/11/the-hipster-effect-interactive/>`_
   to use HoloViews by Philipp Rudiger.
-created: 2017-06-28
-maintainers:
-- philippjfr
-labels:
-- holoviews
+examples_config:
+  created: 2017-06-28
+  maintainers:
+  - philippjfr
+  labels:
+  - holoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/iex_trading/anaconda-project.yml
+++ b/iex_trading/anaconda-project.yml
@@ -2,19 +2,19 @@
 
 name: IEX trading
 description: Dashboard visualizing stock trades on the IEX exchange
-maintainers:
-- jlstevens
-labels:
-- datashader
-- panel
-- holoviews
-- dev
-- channel_pyviz-dev
+examples_config:
+  maintainers:
+  - jlstevens
+  labels:
+  - datashader
+  - panel
+  - holoviews
+  - dev
+  - channel_pyviz-dev
+  skip:
+  - IEX_to_CSV.ipynb
 
-skip:
-- IEX_to_CSV.ipynb
-
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 channels: [pyviz/label/dev]
 
 packages: &pkgs

--- a/landsat/anaconda-project.yml
+++ b/landsat/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: landsat
 description: Datashading LandSat8 raster satellite imagery
-maintainers:
-- jbednar
-labels:
-- geoviews
-- datashader
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - geoviews
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [pyviz]
 

--- a/landsat_clustering/anaconda-project.yml
+++ b/landsat_clustering/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: landsat_clustering
 description: Example of spectral clustering landsat data
-maintainers:
-- jbednar
-labels:
-- datashader
-- geoviews
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [conda-forge]
 

--- a/landuse_classification/anaconda-project.yml
+++ b/landuse_classification/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: landuse_classification
 description: Image classification using the UC Merced Land Use Dataset
-maintainers:
-- jbednar
-labels:
-- datashader
-- geoviews
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/lsystems/anaconda-project.yml
+++ b/lsystems/anaconda-project.yml
@@ -1,12 +1,13 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: lsystems
 description: Lindenmayer system - a mathematical system used to describe growth processes
-maintainers:
-- jlstevens
-labels:
-- holoviews
+examples_config:
+  maintainers:
+  - jlstevens
+  labels:
+  - holoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/ml_annotators/anaconda-project.yml
+++ b/ml_annotators/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: ml_annotators
 description: Using Bokeh/HoloViews/GeoViews for annotating data for ML
-maintainers:
-- jbednar
-labels:
-- holoviews
-- geoviews
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - holoviews
+  - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - pyviz/label/dev

--- a/network_packets/anaconda-project.yml
+++ b/network_packets/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: network_packets
 description: Graphing network packets using networkx, holoviews, and datashader
-maintainers:
-- jbednar
-labels:
-- holoviews
-- datashader
-- networkx
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - holoviews
+  - datashader
+  - networkx
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [conda-forge]
 

--- a/nyc_buildings/anaconda-project.yml
+++ b/nyc_buildings/anaconda-project.yml
@@ -1,12 +1,13 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: nyc_buildings
 description: NYC buildings
-maintainers:
-- philippjfr
-labels:
-- datashader
+examples_config:
+  maintainers:
+  - philippjfr
+  labels:
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - pyviz

--- a/nyc_taxi/anaconda-project.yml
+++ b/nyc_taxi/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: nyc_taxi
 description: Plotting the NYC taxi dataset using Datashader.
-maintainers:
-- jbednar
-labels:
-- datashader
-- panel
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - panel
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/opensky/anaconda-project.yml
+++ b/opensky/anaconda-project.yml
@@ -1,15 +1,16 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: opensky
 description: Datashading OpenSky flight trajectories
-created: 2017-11-03
-maintainers:
-- jbednar
-labels:
-- datashader
+examples_config:
+  created: 2017-11-03
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
 
 channels: []
 
-user_fields: [labels, created, maintainers]
+user_fields: [examples_config]
 
 packages: &pkgs
 - python=3.7

--- a/osm/anaconda-project.yml
+++ b/osm/anaconda-project.yml
@@ -6,7 +6,7 @@ examples_config:
   - jbednar
   labels:
   - datashader
-  skip_doc_evaluation: true
+  skip_project_build: true
 
 user_fields: [examples_config]
 

--- a/osm/anaconda-project.yml
+++ b/osm/anaconda-project.yml
@@ -1,12 +1,13 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: osm
 description: Datashading Open Street Map database
-maintainers:
-- jbednar
-labels:
-- datashader
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - conda-forge

--- a/osm/anaconda-project.yml
+++ b/osm/anaconda-project.yml
@@ -6,6 +6,7 @@ examples_config:
   - jbednar
   labels:
   - datashader
+  skip_doc_evaluation: true
 
 user_fields: [examples_config]
 

--- a/particle_swarms/anaconda-project.yml
+++ b/particle_swarms/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: particle_swarms
 description: Interactive dashboard for Particle Swarm Optimisation
-created: 2020-08-10
-maintainers:
-- scottire
-labels:
-- holoviews
-- panel
+examples_config:
+  created: 2020-08-10
+  maintainers:
+  - scottire
+  labels:
+  - holoviews
+  - panel
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - conda-forge

--- a/penguin_crossfilter/anaconda-project.yml
+++ b/penguin_crossfilter/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: penguins
 description: Palmer Penguin Cross-Filtering
-maintainers:
-- philippjfr
-labels:
-- panel
-- holoviews
-- hvplot
+examples_config:
+  maintainers:
+  - philippjfr
+  labels:
+  - panel
+  - holoviews
+  - hvplot
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - pyviz

--- a/portfolio_optimizer/anaconda-project.yml
+++ b/portfolio_optimizer/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: portfolio_optimizer
 description: Portfolio Optimizer Application
-maintainers:
-- philippjfr
-labels:
-- panel
-- hvplot
-- holoviews
+examples_config:
+  maintainers:
+  - philippjfr
+  labels:
+  - panel
+  - hvplot
+  - holoviews
 
-user_fields: [labels, skip, maintainers, user_fields]
+user_fields: [examples_config]
 
 channels: []
 

--- a/seattle_lidar/anaconda-project.yml
+++ b/seattle_lidar/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: seattle_lidar
 description: Visualize Lidar Scattered Point Elevation Data in Seattle
-maintainers:
-  - jbednar
-labels:
-  - datashader
-  - geoviews
+examples_config:
+  maintainers:
+    - jbednar
+  labels:
+    - datashader
+    - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [conda-forge, pyviz,nodefaults]
 

--- a/ship_traffic/anaconda-project.yml
+++ b/ship_traffic/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: ship_traffic
 description: Visualizing AIS location tracking data for marine vessels near the USA
-maintainers:
-- jbednar
-labels:
-- datashader
-- holoviews
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - datashader
+  - holoviews
 
-user_fields: [labels, skip, maintainers, user_fields]
+user_fields: [examples_config]
 
 channels:
 - pyviz/label/dev

--- a/square_limit/anaconda-project.yml
+++ b/square_limit/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: square_limit
 description: Recreating the Square Limit woodcut by M.C. Escher using Holoviews Spline
-maintainers:
-- jlstevens
-- jbednar
-labels:
-- holoviews
+examples_config:
+  maintainers:
+  - jlstevens
+  - jbednar
+  labels:
+  - holoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/sri_model/anaconda-project.yml
+++ b/sri_model/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: sri_model
 description: Agent based modelling in epidemiology using HoloViews
-created: 2015-01-01
-maintainers:
-- philippjfr
-labels:
-- holoviews
-- networkx
+examples_config:
+  created: 2015-01-01
+  maintainers:
+  - philippjfr
+  labels:
+  - holoviews
+  - networkx
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/template/anaconda-project.yml
+++ b/template/anaconda-project.yml
@@ -1,11 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: NAME
 description: DESC
-created: YYYY-MM-DD
-maintainers:
-  - MAINTAINER
-labels:
-  - LABEL
+examples_config:
+  created: YYYY-MM-DD
+  maintainers:
+    - MAINTAINER
+  labels:
+    - LABEL
+
+user_fields: [examples_config]
 
 channels:
   - pyviz

--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,5 @@ deps = lint: {[_lint]commands}
 [pytest]
 addopts = -v --pyargs --doctest-modules --doctest-ignore-import-errors
 norecursedirs = doc .git dist build _build .ipynb_checkpoints apps
-nbsmoke_cell_timout = 360
+nbsmoke_cell_timeout = 360
 nbsmoke_skip_run = .*iex_trading/IEX_to_CSV.ipynb$

--- a/uk_researchers/anaconda-project.yml
+++ b/uk_researchers/anaconda-project.yml
@@ -1,13 +1,14 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: uk_researchers
 description: UK research networks with HoloViews, Bokeh, and Datashader
-maintainers:
-- philippjfr
-- jbednar
-labels:
-- datashader
+examples_config:
+  maintainers:
+  - philippjfr
+  - jbednar
+  labels:
+  - datashader
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: []
 

--- a/voila_gpx_viewer/anaconda-project.yml
+++ b/voila_gpx_viewer/anaconda-project.yml
@@ -2,14 +2,15 @@
 name: voila-gpx-viewer
 description: Display GPX-format GPS traces, from https://bit.ly/2S6GTa5
 # (https://github.com/jtpio/voila-gpx-viewer)
-maintainers:
-- jbednar
-labels:
-- voila
-- bqplot
-- ipyleaflet
+examples_config:
+  maintainers:
+  - jbednar
+  labels:
+  - voila
+  - bqplot
+  - ipyleaflet
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels:
 - conda-forge

--- a/walker_lake/anaconda-project.yml
+++ b/walker_lake/anaconda-project.yml
@@ -1,14 +1,15 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
 name: walker_lake
 description: Analysis of NDVI over time of Walker Lake, Nevada
-maintainers:
-- jlstevens
-- jbednar
-labels:
-- datashader
-- geoviews
+examples_config:
+  maintainers:
+  - jlstevens
+  - jbednar
+  labels:
+  - datashader
+  - geoviews
 
-user_fields: [labels, skip, maintainers]
+user_fields: [examples_config]
 
 channels: [pyviz,conda-forge]
 


### PR DESCRIPTION
Some projects can't be built on the CI. This can happen when they need to download too much data or that it just takes too long. They may also require computation resources that aren't available on the CI (e.g. GPU). In that case it's useful to be able to declare that the project should not be built. This is now possible with the `skip_project_build` special parameter. On top of that this PR changes the way these kind of projects must be submitted. Instead of pushing them directly to the *evaluated* branch (doing so makes it difficult to track changes), it is expected that the evaluated notebooks should be pushed directly in the PR. It is expected that there shouldn't be too many of these projects, as such, it shouldn't make the repository too big.

(Disclaimer: not yet fully tested!)