### PR TITLE
Fix the build_all workflow

### DIFF
--- a/.github/actions/build_one/action.yml
+++ b/.github/actions/build_one/action.yml
@@ -6,7 +6,7 @@ inputs:
     # Could be a list of the available projects to make it easier to select one
     description: Project to build
     required: true
-  target:
+  build_mode:
     description: Build mode
     required: true
     default: dryrun
@@ -51,8 +51,8 @@ runs:
         doit process_notebooks:${{ inputs.project }}
     - name: deploy project
       shell: bash -l {0}
-      # Deploy only when the target is 'evaluated' on workflow_dispatch, or on push
-      if: (github.event_name == 'workflow_dispatch' && inputs.target == 'evaluated') || github.event_name == 'push'
+      # Deploy only when the build_mode is 'evaluated' on workflow_dispatch, or on push
+      if: (github.event_name == 'workflow_dispatch' && inputs.build_mode == 'evaluated') || github.event_name == 'push'
       run: |
         DIR=${{ inputs.project }}
         git config user.email "travis@travis.org"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
         # Could be a list of the available projects to make it easier to select one
         description: Project to build
         required: true
-      target:
+      build_mode:
         description: Build mode
         type: choice
         options:
@@ -63,7 +63,7 @@ jobs:
         if: steps.vars.outputs.PROJECT_EXISTS == 'true'
         uses: ./.github/actions/build_one
         with:
-          # inputs.target is an empty string if the event is not workflow_dispatch
-          target: ${{ github.event.inputs.target }}
+          # inputs.build_mode is an empty string if the event is not workflow_dispatch
+          build_mode: ${{ github.event.inputs.build_mode }}
           project: ${{ steps.vars.outputs.DIR }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -46,8 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # project: ${{ fromJson(needs.get-build-list.outputs.projects) }}
-        project: ['boids', 'carbon_flux']
+        project: ${{ fromJson(needs.get-build-list.outputs.projects) }}
     steps:
     - uses: actions/checkout@v3
     - name: Build project

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -8,7 +8,7 @@ name: build_all
 on: 
   workflow_dispatch:
     inputs:
-      target:
+      build_mode:
         description: Build mode
         type: choice
         options:
@@ -39,19 +39,20 @@ jobs:
     outputs:
       projects: ${{ steps.set-project-list.outputs.projects }}
   build:
-    name: Build project ${{ matrix.project }} in ${{ github.event.inputs.target }} mode
+    name: Build project ${{ matrix.project }} in ${{ github.event.inputs.build_mode }} mode
     needs: get-build-list
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        project: ${{ fromJson(needs.get-build-list.outputs.projects) }}
+        # project: ${{ fromJson(needs.get-build-list.outputs.projects) }}
+        project: ['boids', 'carbon_flux']
     steps:
     - uses: actions/checkout@v3
-    # - name: Build project
-    #   uses: ./.github/actions/build_one
-    #   with:
-    #     target: ${{ github.event.inputs.target }}
-    #     project: ${{ matrix.project }}
-    #     gh_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build project
+      uses: ./.github/actions/build_one
+      with:
+        build_mode: ${{ github.event.inputs.build_mode }}
+        project: ${{ matrix.project }}
+        gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -1,8 +1,8 @@
 # Build all the projects in dryrun mode:
 # - on demand
 # - every month
-# The list of projects to run is obtained from the repo directories,
-# after ignoring a few of them like `doc/`
+# The list of projects to run is obtained from the repo directories.
+
 name: build_all
 
 on: 
@@ -12,65 +12,46 @@ on:
         description: Build mode
         type: choice
         options:
-        # - evaluated
         - dryrun
         required: true
         default: dryrun
 
 jobs:
-  get-build-matrix:
+  get-build-list:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v3
-      - name: set matrix
-        id: set-matrix
-        shell:  bash -l {0}
-        # List the directories
-        # Remove the ending /
-        # Filter out some directories
-        # Add "" around each directory name
-        # Turn the stream into a list
-        # Remove the last , character
-        # Add [] around the list 
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          auto-activate-base: false
+          activate-environment: examples-gallery-build
+          environment-file: environment-build.yml
+      - name: set project list
+        id: set-project-list
         run: |
-          PROJECTS=$(ls -d */ \
-          | sed 's/.$//' \
-          | grep -v '__pycache__\|template\|doc\|test_data' \
-          | sed 's/^/"/' \
-          | sed 's/$/"/'  \
-          | tr '\n' ',' \
-          | sed 's/.$//' \
-          | sed 's/^/[/' \
-          | sed 's/$/]/')
+          PROJECTS=$(doit list_project_dir_names | tail -n -1)
           echo $PROJECTS
-          echo "::set-output name=project_matrix::$PROJECTS"
+          echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT  
     outputs:
-      project_matrix: ${{ steps.set-matrix.outputs.project_matrix }}
+      projects: ${{ steps.set-project-list.outputs.projects }}
   build:
     name: Build project ${{ matrix.project }} in ${{ github.event.inputs.target }} mode
-    needs: get-build-matrix
+    needs: get-build-list
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        project: ${{ fromJson(needs.get-build-matrix.outputs.project_matrix) }}
+        project: ${{ fromJson(needs.get-build-list.outputs.projects) }}
     steps:
     - uses: actions/checkout@v3
-    - name: Build project
-      uses: ./.github/actions/build_one
-      with:
-        target: ${{ github.event.inputs.target }}
-        project: ${{ matrix.project }}
-        gh_token: ${{ secrets.GITHUB_TOKEN }}
-
-    # - name: Trigger downstream test workflow and wait
-    #   uses: convictional/trigger-workflow-and-wait@v1.6.3
+    # - name: Build project
+    #   uses: ./.github/actions/build_one
     #   with:
-    #     github_token: ${{ secrets.ACCESS_TOKEN }}
-    #     workflow_file_name: build.yaml
-    #     ref: main
-    #     wait_interval: 120
-    #     propagate_failure: true
-    #     trigger_workflow: true
-    #     wait_workflow: true
+    #     target: ${{ github.event.inputs.target }}
+    #     project: ${{ matrix.project }}
+    #     gh_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_all.yml
+++ b/.github/workflows/build_all.yml
@@ -15,6 +15,9 @@ on:
         - dryrun
         required: true
         default: dryrun
+    schedule:
+    # 3rd day of the month at 12 (avoiding 1st day that may have more load)
+    - cron: '0 12 3 * *'
 
 jobs:
   get-build-list:

--- a/dodo.py
+++ b/dodo.py
@@ -128,6 +128,16 @@ def all_project_names(root):
     root = os.path.abspath(root)
     return [f for f in next(os.walk('.'))[1] if f not in DEFAULT_EXCLUDE]
 
+def task_list_project_dir_names():
+    """Print a list of all the project directory names"""
+
+    def list_project_dir_names():
+        print(all_project_names(root=''))
+
+    return {
+        'actions': [list_project_dir_names],
+    }
+
 def task_small_data_setup():
     """Copy small versions of the data from test_data"""
 


### PR DESCRIPTION
The main change in this PR was to replace some bash scripting in the workflow by a doit task.

The build_all workflow can run on demand and will run monthly, attempting to build all the projects in a dry-run mode.