### PR TITLE
Add project header and better handle assets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         project: ${{ fromJson(needs.inferprojects.outputs.projects) }}
-    uses: pyviz-topics/examples/.github/workflows/build_one.yml@fix_sync_merge
+    uses: pyviz-topics/examples/.github/workflows/build_one.yml@handle_metadata
     with:
       project: ${{ matrix.project }}
       type: ${{ inputs.type }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         project: ${{ fromJson(needs.inferprojects.outputs.projects) }}
-    uses: pyviz-topics/examples/.github/workflows/build_one.yml@handle_metadata
+    uses: ./.github/workflows/build_one.yml
     with:
       project: ${{ matrix.project }}
       type: ${{ inputs.type }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,14 +75,14 @@ jobs:
           PROJECTS=$INPUTS
         elif [ "$EVENTNAME" == "workflow_dispatch" ]; then
           if [ "$ALL" == "true" ]; then
-            PROJECTS=$(doit list_project_dir_names | tail -n -1)
+            PROJECTS=$(doit util_list_project_dir_names | tail -n -1)
           else
             echo "$INPUTS" > .projects
-            PROJECTS=$(doit list_comma_separated_projects | tail -n -1)
+            PROJECTS=$(doit util_list_comma_separated_projects | tail -n -1)
             rm .projects
           fi
         elif [ "$EVENTNAME" == "schedule" ]; then
-          PROJECTS=$(doit list_project_dir_names | tail -n -1)
+          PROJECTS=$(doit util_list_project_dir_names | tail -n -1)
         fi
         echo "Projects: $PROJECTS"
         echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT

--- a/.github/workflows/build_one.yml
+++ b/.github/workflows/build_one.yml
@@ -77,7 +77,7 @@ jobs:
         rmdir ./tmp
         git add ./doc/$DIR
         git commit -m "adding $DIR"
-        git push "https://pyviz-developers:${{ secrets.GITHUB_TOKEN }}@github.com/pyviz-topics/examples.git" HEAD:$BRANCHNAME
+        git push --force "https://pyviz-developers:${{ secrets.GITHUB_TOKEN }}@github.com/pyviz-topics/examples.git" HEAD:$BRANCHNAME
         git checkout main
     - name: clean up
       run: doit clean --clean-dep build

--- a/.github/workflows/build_one.yml
+++ b/.github/workflows/build_one.yml
@@ -77,8 +77,7 @@ jobs:
         rmdir ./tmp
         git add ./doc/$DIR
         git commit -m "adding $DIR"
-        # TODO: remove dry run
-        git push --dry-run "https://pyviz-developers:${{ secrets.GITHUB_TOKEN }}@github.com/pyviz-topics/examples.git" HEAD:$BRANCHNAME
+        git push "https://pyviz-developers:${{ secrets.GITHUB_TOKEN }}@github.com/pyviz-topics/examples.git" HEAD:$BRANCHNAME
         git checkout main
     - name: clean up
       run: doit clean --clean-dep build

--- a/.github/workflows/build_one.yml
+++ b/.github/workflows/build_one.yml
@@ -46,9 +46,9 @@ jobs:
         conda install conda-libmamba-solver
         conda config --set solver libmamba
     - name: prepare project
-      run: doit prepare_project:${{ inputs.project }}
+      run: doit build_prepare_project:${{ inputs.project }}
     - name: process notebooks
-      run: doit process_notebooks:${{ inputs.project }}
+      run: doit build_process_notebooks:${{ inputs.project }}
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.project }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -272,7 +272,11 @@ jobs:
           ls
         fi
     - name: archive projects
-      run: doit doc_archive_projects
+      run: |
+        ls
+        cat dodo.py
+        doit list
+        doit doc_archive_projects
     - name: move thumbnails
       run: doit doc_move_thumbnails
     - name: make assets

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -147,7 +147,7 @@ jobs:
           git checkout evaluated
           # Important: assumes there's no whitespace in the project names
           echo "Parse projects to remove them"
-          items=$(echo "$CHANGEDPROJECTS" | jq -c -r '.[]')
+          items=$(echo $CHANGEDPROJECTS | jq -c -r '.[]')
           for item in ${items[@]}; do
               echo "Removing doc/$item..."
               rm -rf doc/%item/
@@ -177,7 +177,7 @@ jobs:
           echo "Checkout the evaluated branch"
           git checkout evaluated
           echo "Parse projects to remove them"
-          items=$(echo "$REMOVEDPROJECTS" | jq -c -r '.[]')
+          items=$(echo $REMOVEDPROJECTS | jq -c -r '.[]')
           for item in ${items[@]}; do
               echo "Removing doc/$item..."
               rm -rf doc/%item/
@@ -205,8 +205,8 @@ jobs:
       # workflow_call events (coming from pr_flow.yml) that did update at least one project
       if: inputs.type == 'workflow_call' && (inputs.changedprojects != '[]' || inputs.removedprojects != '[]' )
       run: |
-        CHANGEDPROJECTS="${{ inputs.changedprojects }}"
-        REMOVEDPROJECTS="${{ inputs.removedprojects }}"
+        CHANGEDPROJECTS='${{ inputs.changedprojects }}'
+        REMOVEDPROJECTS='${{ inputs.removedprojects }}'
         if [ "$CHANGEDPROJECTS" != "[]" ]; then
 
           # We setup the repo so that it has the doc from the dev evaluated branch
@@ -222,7 +222,7 @@ jobs:
           git checkout evaluated
           # Important: assumes there's no whitespace in the project names
           echo "Parse projects to remove them"
-          items=$(echo "$CHANGEDPROJECTS" | jq -c -r '.[]')
+          items=$(echo $CHANGEDPROJECTS | jq -c -r '.[]')
           for item in ${items[@]}; do
               echo "Removing doc/$item..."
               rm -rf doc/%item/
@@ -252,7 +252,7 @@ jobs:
           git checkout evaluated
           # Important: assumes there's no whitespace in the project names
           echo "Parse projects to remove them"
-          items=$(echo "$REMOVEDPROJECTS" | jq -c -r '.[]')
+          items=$(echo $REMOVEDPROJECTS | jq -c -r '.[]')
           for item in ${items[@]}; do
               echo "Removing doc/$item..."
               rm -rf doc/%item/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -133,7 +133,7 @@ jobs:
           exit 1
         fi
 
-        if [ "$CHANGEDPROJECTS" != "[]" ] then;
+        if [ "$CHANGEDPROJECTS" != "[]" ]; then
 
           # Some changes were made, the evaluated branch needs to be updated
           # with new data stored in the tmp dev branch.
@@ -166,7 +166,7 @@ jobs:
           # TODO: remove dryrun
           git push --dry-run "https://pyviz-developers:${{ secrets.GITHUB_TOKEN }}@github.com/pyviz-topics/examples.git" HEAD:evaluated --delete $DEVBRANCH
           git checkout main
-        elif [ "$REMOVEDPROJECTS" != "[]" ] then;
+        elif [ "$REMOVEDPROJECTS" != "[]" ]; then
 
           # One of more projects have been removed, they need to be removed from
           # the evaluated branch.
@@ -207,7 +207,7 @@ jobs:
       run: |
         CHANGEDPROJECTS="${{ inputs.changedprojects }}"
         REMOVEDPROJECTS="${{ inputs.removedprojects }}"
-        if [ "$CHANGEDPROJECTS" != "[]" ] then;
+        if [ "$CHANGEDPROJECTS" != "[]" ]; then
 
           # We setup the repo so that it has the doc from the dev evaluated branch
           # and from the evaluated branch
@@ -240,7 +240,7 @@ jobs:
           git diff
           git log -n 10 --oneline
           tree doc -L 2
-        elif [ "$REMOVEDPROJECTS" != "[]" ] then;
+        elif [ "$REMOVEDPROJECTS" != "[]" ]; then
 
           # We setup the repo so that it has the doc from the dev evaluated branch
           # and from the evaluated branch

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,6 +60,7 @@ on:
         - dryrun
         required: true
         default: dryrun
+    secrets: inherit
   schedule:
     - cron: '0 2 * * SUN'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,6 @@ on:
         - dryrun
         required: true
         default: dryrun
-    secrets: inherit
   schedule:
     - cron: '0 2 * * SUN'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -234,7 +234,7 @@ jobs:
           git diff
           # This isn't meant to be pushed, it's just for this docs build
           git commit -m "Add $CHANGEDPROJECTS"
-          git checkout main
+          git checkout $DEVBRANCH
           # Checkout only the /doc folder than contains the evaluated artefacts
           git checkout evaluated -- ./doc
           git diff
@@ -263,7 +263,7 @@ jobs:
           git diff
           # This isn't meant to be pushed, it's just for this docs build
           git commit -m "Remove $REMOVEDPROJECTS"
-          git checkout main
+          git checkout $DEVBRANCH
           # Checkout only the /doc folder than contains the evaluated artefacts
           git checkout evaluated -- ./doc
           git diff

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -234,7 +234,7 @@ jobs:
           git diff
           # This isn't meant to be pushed, it's just for this docs build
           git commit -m "Add $CHANGEDPROJECTS"
-          git checkout $DEVBRANCH
+          git checkout ${{ github.ref_name }}
           # Checkout only the /doc folder than contains the evaluated artefacts
           git checkout evaluated -- ./doc
           git diff
@@ -263,7 +263,7 @@ jobs:
           git diff
           # This isn't meant to be pushed, it's just for this docs build
           git commit -m "Remove $REMOVEDPROJECTS"
-          git checkout $DEVBRANCH
+          git checkout ${{ github.ref_name }}
           # Checkout only the /doc folder than contains the evaluated artefacts
           git checkout evaluated -- ./doc
           git diff

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@
 #     and `evaluated` branches, merge locally (NOT pushed), and build the dev site
 #   - no project built, checkout `evaluated` and build main site
 # workflow_dispatch: checkout `evaluated` and build main or dev site
-# schedule: checkout `evaluated` and build dev site
+# schedule: checkout `evaluated`, don't build any site
 
 name: docs
 
@@ -299,18 +299,16 @@ jobs:
     - name: Deploy dev
       # workflow_call, by pr_flow.yml
       # workflow_dispatch and dev target
-      # schedule
       if: |
         (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
-        inputs.type == 'workflow_call' ||
-        github.event_name == 'schedule'
+        inputs.type == 'workflow_call'
       run: echo Deploy Dev
-      # uses: peaceiris/actions-gh-pages@v3
-      # with:
-      #   personal_token: ${{ secrets.ACCESS_TOKEN }}
-      #   external_repository: pyviz-dev/examples
-      #   publish_dir: ./builtdocs
-      #   force_orphan: true
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        personal_token: ${{ secrets.ACCESS_TOKEN }}
+        external_repository: pyviz-dev/examples
+        publish_dir: ./builtdocs
+        force_orphan: true
     - name: Deploy main
       # merged PR
       # workflow_dispatch and main target

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -239,7 +239,8 @@ jobs:
           git checkout evaluated -- ./doc
           git diff
           git log -n 10 --oneline
-          tree doc -L 2
+          tree doc -D -h
+          ls
         elif [ "$REMOVEDPROJECTS" != "[]" ]; then
 
           # We setup the repo so that it has the doc from the dev evaluated branch
@@ -267,7 +268,8 @@ jobs:
           git checkout evaluated -- ./doc
           git diff
           git log -n 10 --oneline
-          tree doc -L 2
+          tree doc -D -h
+          ls
         fi
     - name: archive projects
       run: doit doc_archive_projects

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -302,7 +302,6 @@ jobs:
       if: |
         (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'dev') ||
         inputs.type == 'workflow_call'
-      run: echo Deploy Dev
       uses: peaceiris/actions-gh-pages@v3
       with:
         personal_token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,7 +122,7 @@ jobs:
         git fetch https://github.com/${GITHUB_REPOSITORY}.git main:refs/remotes/main
         git checkout main
 
-        CHANGES=$(doit list_changed_dirs_with_last_commit | tail -n -1)
+        CHANGES=$(doit util_list_changed_dirs_with_last_commit | tail -n -1)
 
         CHANGEDPROJECTS=$(echo $CHANGES | jq -c -r '.changed')
         REMOVEDPROJECTS=$(echo $CHANGES | jq -c -r '.removed')
@@ -270,17 +270,17 @@ jobs:
           tree doc -L 2
         fi
     - name: archive projects
-      run: doit archive_project
+      run: doit doc_archive_projects
     - name: move thumbnails
-      run: doit move_thumbnails
+      run: doit doc_move_thumbnails
     - name: make assets
-      run: doit make_assets
+      run: doit doc_move_assets
     - name: "temp: remove non evaluated projects"
-      run: doit remove_doc_not_evaluated
+      run: doit doc_remove_not_evaluated
     - name: build website
-      run: doit build_website
+      run: doit doc_build_website
     - name: build index redirects
-      run: doit index_redirects
+      run: doit doc_index_redirects
       # ZIP and upload the built site:
       # Only when called from pr_flow.yml. Done as multiple PRs can update the dev website
       # concurrently, this offers a way to download the site and see it locally.
@@ -324,7 +324,7 @@ jobs:
       #   cname: examples.pyviz.org
       #   force_orphan: true
     - name: Clean up
-      run: doit clean --clean-dep website
+      run: doit clean --clean-dep doc
     - name: debug
       run: |
         ls -hla

--- a/.github/workflows/pr_flow.yml
+++ b/.github/workflows/pr_flow.yml
@@ -54,23 +54,24 @@ jobs:
         echo "REMOVEDPROJECTS=$REMOVEDPROJECTS" >> $GITHUB_OUTPUT
   test:
     needs: setup
-    uses: pyviz-topics/examples/.github/workflows/test.yml@handle_metadata
+    uses: ./.github/workflows/test.yml
     with:
       projects: ${{ needs.setup.outputs.changedprojects }}
       type: workflow_call
   build:
     needs: [setup, test]
-    uses: pyviz-topics/examples/.github/workflows/build.yml@handle_metadata
+    uses: ./.github/workflows/build.yml
     with:
       projects: ${{ needs.setup.outputs.changedprojects }}
       type: workflow_call
   docs:
     needs: [setup, build]
     if: needs.build.result == 'success' || needs.build.result == 'skipped'
-    uses: pyviz-topics/examples/.github/workflows/docs.yml@handle_metadata
+    uses: ./.github/workflows/docs.yml
     with:
       target: dev
       evaluated_branch: "tmp_evaluated_fghgf_${{  github.ref_name }}"
       changedprojects: ${{ needs.setup.outputs.changedprojects }}
       removedprojects: ${{ needs.setup.outputs.removedprojects }}
       type: workflow_call
+    secrets: inherit

--- a/.github/workflows/pr_flow.yml
+++ b/.github/workflows/pr_flow.yml
@@ -54,20 +54,20 @@ jobs:
         echo "REMOVEDPROJECTS=$REMOVEDPROJECTS" >> $GITHUB_OUTPUT
   test:
     needs: setup
-    uses: pyviz-topics/examples/.github/workflows/test.yml@fix_sync_merge
+    uses: pyviz-topics/examples/.github/workflows/test.yml@handle_metadata
     with:
       projects: ${{ needs.setup.outputs.changedprojects }}
       type: workflow_call
   build:
     needs: [setup, test]
-    uses: pyviz-topics/examples/.github/workflows/build.yml@fix_sync_merge
+    uses: pyviz-topics/examples/.github/workflows/build.yml@handle_metadata
     with:
       projects: ${{ needs.setup.outputs.changedprojects }}
       type: workflow_call
   docs:
     needs: [setup, build]
     if: needs.build.result == 'success' || needs.build.result == 'skipped'
-    uses: pyviz-topics/examples/.github/workflows/docs.yml@fix_sync_merge
+    uses: pyviz-topics/examples/.github/workflows/docs.yml@handle_metadata
     with:
       target: dev
       evaluated_branch: "tmp_evaluated_fghgf_${{  github.ref_name }}"

--- a/.github/workflows/pr_flow.yml
+++ b/.github/workflows/pr_flow.yml
@@ -36,7 +36,7 @@ jobs:
     - name: infer project list
       id: set-list
       run: |
-        CHANGES=$(doit list_changed_dirs_with_main | tail -n -1)
+        CHANGES=$(doit util_list_changed_dirs_with_main | tail -n -1)
 
         CHANGEDPROJECTS=$(echo $CHANGES | jq -c -r '.changed')
         REMOVEDPROJECTS=$(echo $CHANGES | jq -c -r '.removed')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,14 +66,14 @@ jobs:
           PROJECTS=$INPUTS
         elif [ "$EVENTNAME" == "workflow_dispatch" ]; then
           if [ "$ALL" == "true" ]; then
-            PROJECTS=$(doit list_project_dir_names | tail -n -1)
+            PROJECTS=$(doit util_list_project_dir_names | tail -n -1)
           else
             echo "$INPUTS" > .projects
-            PROJECTS=$(doit list_comma_separated_projects | tail -n -1)
+            PROJECTS=$(doit util_list_comma_separated_projects | tail -n -1)
             rm .projects
           fi
         elif [ "$EVENTNAME" == "schedule" ]; then
-          PROJECTS=$(doit list_project_dir_names | tail -n -1)
+          PROJECTS=$(doit util_list_project_dir_names | tail -n -1)
         fi
         echo "Projects: $PROJECTS"
         echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,6 @@ jobs:
      fail-fast: false
      matrix:
        project: ${{ fromJson(needs.inferprojects.outputs.projects) }}
-    uses: pyviz-topics/examples/.github/workflows/test_one.yml@fix_sync_merge
+    uses: pyviz-topics/examples/.github/workflows/test_one.yml@handle_metadata
     with:
       project: ${{ matrix.project }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,6 @@ jobs:
      fail-fast: false
      matrix:
        project: ${{ fromJson(needs.inferprojects.outputs.projects) }}
-    uses: pyviz-topics/examples/.github/workflows/test_one.yml@handle_metadata
+    uses: ./.github/workflows/test_one.yml
     with:
       project: ${{ matrix.project }}

--- a/.github/workflows/test_one.yml
+++ b/.github/workflows/test_one.yml
@@ -58,11 +58,11 @@ jobs:
     - name: validate thumbnails
       run: doit validate_thumbnails:${{ inputs.project }}
     - name: small data setup
-      run: doit small_data_setup:${{ inputs.project }}
+      run: doit test_small_data_setup:${{ inputs.project }}
     - name: prepare project
-      run: doit prepare_project_test:${{ inputs.project }}
+      run: doit test_prepare_project:${{ inputs.project }}
     - name: lint project
-      run: doit lint_project:${{ inputs.project }}
+      run: doit test_lint_project:${{ inputs.project }}
     - name: test project
       run: doit test_project:${{ inputs.project }}
     - name: complete clean up and diff

--- a/.gitignore
+++ b/.gitignore
@@ -37,17 +37,17 @@ doc/*/
 !doc/_static/
 !doc/_templates/
 
-# Ignore output of make_assets
+# Ignore output of doc_move_assets
 assets/
 # but don't ignore the projname/assets/
 !*/assets/
 
-# Ignore output of build_website
+# Ignore output of doc_build_website
 jupyter_execute/
 builtdocs/
 
 # Ignore output of the git diff 
 .diff
 
-# Ignore output of small_data_setup
+# Ignore output of test_small_data_setup
 */tmp_catalog.yml

--- a/boids/anaconda-project.yml
+++ b/boids/anaconda-project.yml
@@ -7,6 +7,8 @@ examples_config:
     - jlstevens
   labels:
     - holoviews
+  deployments:
+    - command: "notebook"
 
 user_fields: [examples_config]
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,1 +1,0 @@
-Site built with nbsite; see nbsite.pyviz.org for details and instructions.

--- a/doc/_static/site.css
+++ b/doc/_static/site.css
@@ -136,3 +136,15 @@ button.copybtn:hover {
 ul.current.nav.bd-sidenav {
   padding: 0;
 }
+
+
+/* Paragraphs in the metadata header displayed above each notebook
+had their margin-bottom set by the PyData Sphinx Theme.
+
+This sets it to 0 and is inspired by what Sphinx-Design does for its article-info
+directive. Sphinx-Design is what is used on examples to implement the header as a grid.
+https://github.com/executablebooks/sphinx-design/blob/cca2cfb1b4c0a55ecf6661889c52ea320d42f58f/sphinx_design/article_info.py#L46
+*/
+div.nbsite-metadata > p {
+  margin-bottom: 0 !important;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -145,15 +145,19 @@ def gallery_spec(name):
         for depl in deployments:
             if depl['command'] == 'notebook':
                 text = 'Run notebook'
-                icon_type = 'smart_display'
+                material_icon = 'smart_display'
                 # TOOD: check how it works with multiple notebooks
                 endpoint = f'{server_name}-notebook.pyviz.demo.anaconda.com'
+                # nbsite will look for "/notebooks/{template_notebook_filename}"
+                # and replace {template_notebook_filename} by the notebook
+                # filename where the metadata prolog is injected.
+                endpoint += '/notebooks/{template_notebook_filename}'
             elif depl['command'] == 'dashboard':
                 text = 'Open app'
-                icon_type = 'dashboard'
+                material_icon = 'dashboard'
                 endpoint = f'{server_name}.pyviz.demo.anaconda.com'
             formatted_depl = DEPLOYMENT_TEMPLATE.format(
-                text=text, icon_type=icon_type, endpoint=endpoint
+                text=text, material_icon=material_icon, endpoint=endpoint
             )
             _formatted_deployments.append(formatted_depl)
         deployments = '\n\n'.join(_formatted_deployments)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -147,7 +147,7 @@ def gallery_spec(name):
                 text = 'Run notebook'
                 material_icon = 'smart_display'
                 # TOOD: check how it works with multiple notebooks
-                endpoint = f'{server_name}-notebook.pyviz.demo.anaconda.com'
+                endpoint = f'https://{server_name}-notebook.pyviz.demo.anaconda.com'
                 # nbsite will look for "/notebooks/{template_notebook_filename}"
                 # and replace {template_notebook_filename} by the notebook
                 # filename where the metadata prolog is injected.
@@ -155,7 +155,7 @@ def gallery_spec(name):
             elif depl['command'] == 'dashboard':
                 text = 'Open app'
                 material_icon = 'dashboard'
-                endpoint = f'{server_name}.pyviz.demo.anaconda.com'
+                endpoint = f'https://{server_name}.pyviz.demo.anaconda.com'
             formatted_depl = DEPLOYMENT_TEMPLATE.format(
                 text=text, material_icon=material_icon, endpoint=endpoint
             )

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -93,7 +93,7 @@ PROLOG_TEMPLATE = """
             :columns: auto
             :class: nbsite-metadata
 
-            :material-outlined:`download;24px` `Download project </assets/_archives/{projectname}.zip>`_
+            :material-outlined:`download;24px` `Download project <../assets/_archives/{projectname}.zip>`_
 
 {deployments}
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,10 +1,19 @@
 # -*- coding: utf-8 -*-
-from nbsite.shared_conf import *
-import os
 import glob
+import os
+import sys
+
 import yaml
 
-EXCLUDE = ['assets', *glob.glob( '.*'), *glob.glob( '_*')]
+from nbsite.shared_conf import *
+
+# To reuse utilities in dodo.py
+sys.path.insert(0, '..')
+
+from dodo import (
+    all_project_names, last_commit_date, projname_to_servername,
+    projname_to_title, DEFAULT_DOC_EXCLUDE
+)
 
 project = u'Examples'
 authors = u'PyViz Developers'
@@ -40,24 +49,120 @@ extensions += [
     'IPython.sphinxext.ipython_console_highlighting',
 ]
 
-# Turn off myst-nb execute (should not be required, but...)
+# Turn off myst-nb execute (should not be required, but who knows!)
 nb_execution_mode = 'off'
+
+PROLOG_TEMPLATE = """
+.. grid:: 1 1 1 2
+   :outline:
+   :padding: 2
+   :margin: 2 4 2 2
+   :class-container: sd-rounded-1
+
+   .. grid-item::
+      :columns: 12
+      :margin: 0
+      :padding: 0
+
+      .. grid:: 1 1 1 2
+         :margin: 0
+         :padding: 1
+
+         .. grid-item::
+            :columns: auto
+            :class: nbsite-metadata
+
+            :material-outlined:`person;24px` {authors}
+
+         .. grid-item::
+            :columns: auto
+            :class: nbsite-metadata
+
+            :material-outlined:`event;24px` {created} (Last Updated: {last_updated})
+
+   .. grid-item::
+      :columns: 12
+      :margin: 0
+      :padding: 0
+
+      .. grid:: 1 1 1 3
+         :margin: 0
+         :padding: 1
+
+         .. grid-item::
+            :columns: auto
+            :class: nbsite-metadata
+
+            :material-outlined:`download;24px` `Download project </assets/_archives/{projectname}.zip>`_
+
+{deployments}
+
+"""
+
+# Tried using the `download` role, with which Sphinx handles entirely the files to download.
+# It grabs them and puts them in a _downloads folder, with a hash to prevent collisions.
+# However the link was styled in a weird way (`downloads` not handled by the PyData Sphinx Theme?)
+# Keeping that trick around as it is how it should be done, assuming the archives is in doc/projname/
+# :download:`Download project <{projectname}.zip>`
+
+AUTHOR_TEMPLATE = '`{author} <https://github.com/{author}>`_'
+DEPLOYMENT_TEMPLATE = """
+         .. grid-item::
+            :columns: auto
+            :class: nbsite-metadata
+
+            :material-outlined:`{material_icon};24px` `{text} <{endpoint}>`_
+"""
 
 def gallery_spec(name):
     path = os.path.join('..', name, 'anaconda-project.yml')
     with open(path) as f:
         spec = yaml.safe_load(f)
-    url_name = name.replace('_', '-')
-    # TODO: ask if it would be possible to move them to a holoviz domain
-    # TODO: ask where the AE5 instance is actually located? Do we know how much it costs?
-    deployment_urls = [
-            f'https://{url_name}.pyviz.demo.anaconda.com',
-            f'https://{url_name}-notebooks.pyviz.demo.anaconda.com']
-    title = spec['name']
+    title = projname_to_title(spec['name'])
     description = spec['description']
     # Examples specific spec.
+    # TODO: isn't optional
     examples_config = spec.get('examples_config', {})
+    # TODO: isn't optional
     labels = examples_config.get('labels', [])
+    # TODO: isn't optional
+    created = examples_config.get('created', 'NA')
+    # TODO: isn't optional
+    authors = examples_config.get('maintainers', '')
+    # TODO: is optional, if not provided is computed
+    last_updated = examples_config.get('last_updated', '')
+    if not last_updated:
+        last_updated = last_commit_date(name, root='..', verbose=False)
+    deployments = examples_config.get('deployments', '')
+
+    if authors:
+        authors = [AUTHOR_TEMPLATE.format(author=author) for author in authors]
+        authors = ', '.join(authors)
+
+    if deployments:
+        _formatted_deployments = []
+        server_name =   projname_to_servername(spec['name'])
+        for depl in deployments:
+            if depl['command'] == 'notebook':
+                text = 'Run notebook'
+                icon_type = 'smart_display'
+                # TOOD: check how it works with multiple notebooks
+                endpoint = f'{server_name}-notebook.pyviz.demo.anaconda.com'
+            elif depl['command'] == 'dashboard':
+                text = 'Open app'
+                icon_type = 'dashboard'
+                endpoint = f'{server_name}.pyviz.demo.anaconda.com'
+            formatted_depl = DEPLOYMENT_TEMPLATE.format(
+                text=text, icon_type=icon_type, endpoint=endpoint
+            )
+            _formatted_deployments.append(formatted_depl)
+        deployments = '\n\n'.join(_formatted_deployments)
+
+    prolog = PROLOG_TEMPLATE.format(
+        created=created, authors=authors, last_updated=last_updated,
+        projectname=name, deployments=deployments,
+    )
+
     skip = examples_config.get('skip', False)
     
     return {
@@ -65,27 +170,20 @@ def gallery_spec(name):
         'title': title,
         'description': description,
         'labels': labels,
+        'prolog': prolog,
         'skip': skip,
-        'deployment_urls': deployment_urls,
     }
 
-DIR = os.getenv('DIR')
-if DIR:
-    projects = [DIR]
-else:
-    projects = sorted([f for f in next(os.walk('.'))[1] if f not in EXCLUDE])
-    projects = [p for p in projects if p!='grabcut']
-    print('PROJECTS:', projects)
+# Only build the projects found in doc/
+projects = all_project_names(root='.', exclude=DEFAULT_DOC_EXCLUDE)
+print('Projects that will be built:', projects)
 
 nbsite_gallery_inlined_conf = {
     'github_org': 'pyviz-topics',
     'github_project': 'examples',
-    'host': 'assets',
-    'download_as': 'project',
     'examples_dir': '..',
     'alternative_toctree': ['user_guide', 'make_project', 'maintenance'],
     'default_extensions': ['*.ipynb'],
-    'only_use_existing': DIR is None,
     'path': '.',
     'title': 'PyViz Topics Examples',
     'intro': long_description,

--- a/dodo.py
+++ b/dodo.py
@@ -850,14 +850,14 @@ def task_process_notebooks():
         skip_notebooks_evaluation = should_skip_notebooks_evaluation(name)
         if not skip_notebooks_evaluation:
             actions = [
-                f'install kernel {name}-kernel',
+                f'echo "install kernel {name}-kernel"',
                 # Setup Kernel
                 f'conda run --prefix {name}/envs/default python -m ipykernel install --user --name={name}-kernel',
                 # Run notebooks with that kernel
                 (run_notebooks, [name]),
             ]
             teardown = [
-                f'remove kernel {name}-kernel',
+                f'echo "remove kernel {name}-kernel"',
                 # Remove Kernel
                 f'conda run --prefix {name}/envs/default jupyter kernelspec remove {name}-kernel -f',
             ]

--- a/dodo.py
+++ b/dodo.py
@@ -1231,9 +1231,11 @@ def task_doc_move_thumbnails():
             if path.is_dir():
                 print(f'Removing thumbnails folder {path}')
                 shutil.rmtree(path)
+        remove_empty_dirs('doc')
 
     return {
         'actions': [move_thumbnails],
+        'params': [name_param],
         'clean': [clean_thumbnails],
     }
 
@@ -1268,7 +1270,7 @@ def task_doc_move_assets():
             if not dest_assets_path.exists():
                 print(f'Creating dirs {dest_assets_path}')
                 os.makedirs(dest_assets_path)
-            print('Copying tree {proj_assets_path} to {dest_assets_path}')
+            print(f'Copying tree {proj_assets_path} to {dest_assets_path}')
             shutil.copytree(proj_assets_path, dest_assets_path, dirs_exist_ok=True)
 
     def clean_assets():
@@ -1330,13 +1332,13 @@ def task_doc_get_evaluated():
             # Fetch the evaluated branch containing the evaluated projects
             'git fetch https://github.com/%(githubrepo)s.git evaluated:refs/remotes/evaluated',
             # Checkout the doc/ folder from that branch into the current branch
-            'git checkout evaluated -- ./doc',
+            'git checkout evaluated -- ./doc/%(name)s',
             # The previous command stages all what is in doc/, unstage that.
             # This is better UX when building the site locally, not needed on the CI.
             'git reset doc/',
         ],
         'clean': [clean_doc],
-        'params': [githubrepo_param]
+        'params': [githubrepo_param, name_param]
 }
 
 
@@ -1528,7 +1530,7 @@ def task_doc():
     return {
         'actions': None,
         'task_dep': [
-            'doc_archive_project',
+            'doc_archive_projects',
             'doc_move_thumbnails',
             'doc_move_assets',
             'doc_get_evaluated',

--- a/dodo.py
+++ b/dodo.py
@@ -1,3 +1,5 @@
+# Only import from the standard lib, to keep this module easily importable!
+# Inline external libraries imports.
 import contextlib
 import datetime
 import glob
@@ -8,11 +10,9 @@ import pathlib
 import shutil
 import struct
 import subprocess
+import textwrap
 
-DOIT_CONFIG = {
-    "verbosity": 2,
-    "backend": "sqlite3",
-}
+##### Globals and default config #####
 
 DEFAULT_EXCLUDE = [
     'doc',
@@ -33,24 +33,11 @@ DEFAULT_DOC_EXCLUDE = [
 
 NOTEBOOK_EVALUATION_TIMEOUT = 3600  # 1 hour, in seconds.
 
-name_param = {
-    'name': 'name',
-    'long': 'name',
-    'type': str,
-    'default': 'all'
-}
+#### doit config and shared parameters ####
 
-githubrepo_param = {
-    'name': 'githubrepo',
-    'type': str,
-    'default': 'pyviz-topics/examples'
-}
-
-sha_param = {
-    'name': 'sha',
-    'long': 'sha',
-    'type': str,
-    'default': ''
+DOIT_CONFIG = {
+    "verbosity": 2,
+    "backend": "sqlite3",
 }
 
 env_spec_param = {
@@ -60,70 +47,65 @@ env_spec_param = {
     'default': 'default'
 }
 
+githubrepo_param = {
+    'name': 'githubrepo',
+    'type': str,
+    'default': 'pyviz-topics/examples'
+}
+
+name_param = {
+    'name': 'name',
+    'long': 'name',
+    'type': str,
+    'default': 'all'
+}
+
+sha_param = {
+    'name': 'sha',
+    'long': 'sha',
+    'type': str,
+    'default': ''
+}
+
+##### Exceptions ####
 
 class ExamplesError(Exception):
     """Base error"""
 
 
 class ValidationError(Exception):
-    """Base error"""
+    """Validation error"""
 
 
-@contextlib.contextmanager
-def removing_files(paths):
-    already_there = []
-    for path in paths:
-        already_there.append(path.is_file())
-    yield
-    for path in paths:
-        if path not in already_there:
-            if path.is_file():
-                print(f'Removing {path}')
-                path.unlink()
+#### Utils ####
 
-def remove_empty_dirs(path):
-    # Remove children dirs
-    for root, dirnames, _ in os.walk(path, topdown=False):
-        for dirname in dirnames:
-            p = os.path.realpath(os.path.join(root, dirname))
-            error = False
-            try:
-                os.rmdir(p)
-            except OSError:
-                error = True
-            if not error:
-                print(f'Removed empty dir {p}')
-    # Remove root dir
-    error = False
-    try:
-        os.rmdir(path)
-    except OSError:
-        error = True
-    if not error:
-        print(f'Removed empty dir {path}')
-
-def _prepare_paths(root, name, test_data, filename='catalog.yml'):
+def all_project_names(root, exclude=DEFAULT_EXCLUDE):
+    """
+    Return a sorted list of the projects directory names.
+    """
     if root == '':
         root = os.getcwd()
     root = os.path.abspath(root)
-    test_data = test_data if os.path.isabs(test_data) else os.path.join(root, test_data)
-    test_path = os.path.join(test_data, name)
-    project_path = os.path.join(root, name)
-    return {
-        # Path to the project, e.g. ./projname
-        'project': project_path,
-        # Path to the real data folder, e.g. ./projname/data
-        'real': os.path.join(project_path, 'data'),
-        # Path to the test data folder, e.g. ./test_data/projname
-        'test': test_path,
-        # Path to the real intake catalog, e.g. ./projname/catalog.yml
-        'cat_real': os.path.join(project_path, filename),
-        # Path to the real intake catalog, e.g. ./test_data/projname/catalog.yml
-        'cat_test': os.path.join(test_path, filename),
-        # Path to the temporary intake catalog, e.g. ./projname/tmp_catalog.yml
-        # This is used to store the original catalog
-        'cat_tmp': os.path.join(project_path, 'tmp_' + filename),
-    }
+    projects = []
+    for path in pathlib.Path(root).iterdir():
+        if not path.is_dir():
+            continue
+        if path.name in exclude:
+            continue
+        projects.append(path.name)
+    return sorted(projects)
+
+
+def complain(msg):
+    """
+    Print a warning, unless the environment variable
+    HOLOVIZ_EXAMPLES_WARNING_AS_ERROR is set to anything different than '0'.
+    """
+    if os.getenv('HOLOVIZ_EXAMPLES_WARNING_AS_ERROR', '0') != '0':
+        raise ValidationError(msg)
+    else:
+        print('WARNING: ' + msg)
+
 
 def find_notebooks(proj_dir_name, exclude_config=['skip']):
     """
@@ -144,55 +126,28 @@ def find_notebooks(proj_dir_name, exclude_config=['skip']):
     return notebooks
 
 
-def complain(msg):
+def get_png_dims(fname):
     """
-    Print a warning, unless the environment variable
-    HOLOVIZ_EXAMPLES_WARNING_AS_ERROR is set to anything different than '0'.
+    From https://stackoverflow.com/a/20380514/10875966
     """
-    if os.getenv('HOLOVIZ_EXAMPLES_WARNING_AS_ERROR', '0') != '0':
-        raise ValidationError(msg)
-    else:
-        print('WARNING: ' + msg)
+    with open(fname, 'rb') as fhandle:
+        head = fhandle.read(24)
+        if len(head) != 24:
+            raise ValueError
+        imgtype = imghdr.what(fname)
+        if imghdr.what(fname) == 'png':
+            check = struct.unpack('>i', head[4:8])[0]
+            if check != 0x0d0a1a0a:
+                return
+            width, height = struct.unpack('>ii', head[16:24])
+        else:
+            raise ValueError(f'Only supports PNG, not {imgtype}')
+        return width, height
 
-def project_spec(projname, filename='anaconda-project.yml'):
-    from yaml import safe_load
-
-    path = pathlib.Path(projname) / filename
-    with open(path, 'r') as f:
-        spec = safe_load(f)
-    return spec
-
-def all_project_names(root, exclude=DEFAULT_EXCLUDE):
-    """
-    Return a sorted list of the projects directory names.
-    """
-    if root == '':
-        root = os.getcwd()
-    root = os.path.abspath(root)
-    projects = []
-    for path in pathlib.Path(root).iterdir():
-        if not path.is_dir():
-            continue
-        if path.name in exclude:
-            continue
-        projects.append(path.name)
-    return sorted(projects)
-
-def projname_to_servername(name):
-    """
-    Replace '_' by '-'. Assumes projname only has [a-z_]
-    """
-    return name.replace('_', '-')
-
-def projname_to_title(name):
-    """
-    Replace '_' by ' ' and apply `.title()`. Assumes projname only has [a-z_]
-    """
-    return name.replace('_', ' ').title()
 
 def last_commit_date(name, root='.', verbose=True):
     """
-    Return the last committer data as YYYY-MM-DD
+    Return the last committer data as 'YYYY-MM-DD'
     """
     proc = subprocess.run(
         [f'git log -n 1 --pretty=format:%cs {root}/{name}'],
@@ -205,462 +160,6 @@ def last_commit_date(name, root='.', verbose=True):
         print(f'Last commit date: {last_committer_date}')
     return last_committer_date
 
-def task_last_commit_date():
-    """
-    Print the last committer date.
-    """
-
-    for name in all_project_names(root=''):
-        yield {
-            'name': name,
-            'actions': [(last_commit_date, [name])]
-        }
-
-def task_list_project_dir_names():
-    """Print a list of all the project directory names"""
-
-    def list_project_dir_names():
-        print(all_project_names(root=''))
-
-    return {
-        'actions': [list_project_dir_names],
-    }
-
-def task_list_comma_separated_projects():
-    """Print a list of all the projects found in .projects
-    
-    They are expected to be comma separated
-    """
-
-    def list_comma_separated_projects(file='.projects'):
-        file = pathlib.Path(file)
-        if not file.exists():
-            raise FileNotFoundError(f'File {file} not found')
-        projects = file.read_text().strip()
-        if not projects:
-            raise ValueError(f'Missing comma separated projects in {file}')
-        projects = projects.split(',')
-        all_projects = all_project_names(root='')
-        for project in projects:
-            if project not in all_projects:
-                raise ValueError(f'Listed project {project} not found, check its name.')
-        print(projects)
-
-    return {
-        'actions': [list_comma_separated_projects],
-    }
-
-def task_small_data_setup():
-    """Copy small versions of the data from test_data/
-    
-    Small test data is available when a folder with the same name as the
-    project's folder name is found in the `./test_data/` folder (it must
-    include some files).
-
-    If the project depends on an Intake catalog, and `./test_data/` contains
-    an Intake catalog, the project's catalog will be temporarily replaced
-    by the test catalog.
-
-    All the data found in the `./test_data/projname/` folder, but the Intake
-    catalog if any,  will be copied over to the `./projname/data/` folder.
-
-    IMPORTANT: Test data for one project can depend on test data of another
-    project (e.g. via relative links in the intake catalog). This does not
-    affect the implementation of this task, but is worth noting.
-    """
-
-    def copy_test_data(name, root='', test_data='test_data', cat_filename='catalog.yml'):
-        paths = _prepare_paths(root, name, test_data, cat_filename)
-
-        # Not small test data found, nothing to copy.
-        if not os.path.exists(paths['test']):
-            return
-
-        has_test_catalog = os.path.exists(paths['cat_test'])
-
-        if has_test_catalog:
-            print('* Copying intake catalog ...')
-
-            # move real catalog file to tmp if tmp doesn't exist
-            if os.path.exists(paths['cat_tmp']):
-                raise ValueError(
-                    "Fail: Temp file already exists - try "
-                    f"'doit clean small_data_setup:{name}'"
-                )
-            os.rename(paths['cat_real'], paths['cat_tmp'])
-
-            # move test catalog to project directory
-            shutil.copyfile(paths['cat_test'], paths['cat_real'])
-            print(f"  Intake catalog successfully copied from {paths['cat_test']} to {paths['cat_real']}")
-
-        if (os.path.exists(paths['test'])
-            and os.listdir(paths['test']) == ['catalog.yml']):
-            # The only data was the catalog, that has already been processed.
-            return
-
-        print('* Copying test data ...')
-        if os.path.exists(paths['real']):
-            raise FileExistsError(
-                f"Found unexpected {paths['real']}, run "
-                f"'doit clean small_data_setup:{name}'"
-            )
-
-        ignore_catalog = shutil.ignore_patterns('catalog.yml')
-        shutil.copytree(paths['test'], paths['real'], ignore=ignore_catalog)
-        print(f"  Test data sucessfully copied from {paths['test']} to {paths['real']}")
-
-    def remove_test_data(name, root='', test_data='test_data', cat_filename='catalog.yml'):
-        paths = _prepare_paths(root, name, test_data, cat_filename)
-
-        # No small test data found, no need to clean anything.
-        if not os.path.exists(paths['test']):
-            return
-
-        if os.path.exists(paths['cat_real']):
-            print("* Replacing intake catalog ...")
-
-            if not os.path.exists(paths['cat_tmp']):
-                print("Nothing to do: No temp file found. Use git status to "
-                      f"check that you have the real catalog at {paths['cat_real']}")
-            else:
-                os.remove(paths['cat_real'])
-                os.rename(paths['cat_tmp'], paths['cat_real'])
-                print('  Intake catalog successfully cleaned')
-
-        print('* Removing test data ...')
-
-        if not os.path.exists(paths['real']):
-            print('  No data to remove')
-            return
-        elif not os.listdir(paths['real']):
-            os.rmdir(paths['real'])
-            print(f"  No data found in {paths['real']}, just removed empty dir")
-        else:
-            shutil.rmtree(paths['real'])
-            print(f"  Test data successfully removed from {paths['real']}")
-
-    for name in all_project_names(root=''):
-        yield {
-            'name': name,
-            'actions': [(copy_test_data, [name])],
-            'clean': [(remove_test_data, [name])],
-        }
-
-def task_archive_project():
-    """Archive project with given name, assumes anaconda-project is in env"""
-
-    def archive_project(root='', name='all'):
-        projects = all_project_names(root) if name == 'all'  else [name]
-        for project in projects:
-            _archive_project(project)
-
-    def _archive_project(project):
-        from yaml import safe_dump
-
-
-        has_project_ignore = False
-        projectignore_path = pathlib.Path(project, '.projectignore')
-        if projectignore_path.exists():
-            has_project_ignore = True
-
-        has_readme = False
-        readme_path = pathlib.Path(project, 'README.md')
-        if readme_path.exists():
-            has_readme = True
-
-        print(f'Archiving {project}...')
-        if not os.path.exists(readme_path):
-            shutil.copyfile('README.md', readme_path)
-
-        # stripping extra fields out of anaconda_project to make them more legible
-        path = os.path.join(project, 'anaconda-project.yml')
-        tmp_path = f'{project}_anaconda-project.yml'
-        shutil.copyfile(path, tmp_path)
-        spec = project_spec(project)
-
-        # special field that anaconda-project doesn't know about
-        spec.pop('examples_config', '')
-        spec.pop('user_fields', '')
-
-        # commands and envs that users don't need
-        spec['commands'].pop('test', '')
-        spec['commands'].pop('lint', '')
-        spec['env_specs'].pop('test', '')
-
-        # get rid of any empty fields
-        spec = {k: v for k, v in spec.items() if bool(v)}
-
-        with open(path, 'w') as f:
-            safe_dump(spec, f, default_flow_style=False, sort_keys=False)
-
-        archives_path = os.path.join('assets', '_archives')
-        if not os.path.exists(archives_path):
-            os.makedirs(archives_path)
-
-        subprocess.run(
-            ["anaconda-project", "archive", "--directory", f"{project}", f"assets/_archives/{project}.zip"],
-            check=True
-        )
-        shutil.copyfile(tmp_path, path)
-        os.remove(tmp_path)
-
-        if not has_project_ignore:
-            print(f'Removing temp {projectignore_path}')
-            projectignore_path.unlink()
-        if not has_readme:
-            print(f'Removing temp {readme_path}')
-            readme_path.unlink()
-
-    def clean_archive():
-        projects = all_project_names(root='')
-        for project in projects:
-            _clean_archive(project)
-        assets_path = pathlib.Path('assets')
-        remove_empty_dirs(assets_path)
-
-    def _clean_archive(project):
-        _archives_path = pathlib.Path('assets', '_archives')
-        if not _archives_path.exists():
-            return
-        archive_path = _archives_path / f'{project}.zip'
-        print(f'Removing {archive_path}')
-        archive_path.unlink(archive_path)
-
-    return {
-        'actions': [archive_project],
-        'params': [name_param],
-        'clean': [clean_archive]
-    }
-
-def task_move_thumbnails():
-    """Move the thumbnails from the project dir to the project doc dir"""
-
-    def move_thumbnails(root='', name='all'):
-        projects = all_project_names(root) if name == 'all'  else [name]
-        for project in projects:
-            _move_thumbnails(project)
-
-    def _move_thumbnails(name):
-        src_dir = os.path.join(name, 'thumbnails')
-        dst_dir = os.path.join('doc', name, 'thumbnails')
-        if os.path.exists(src_dir):
-            if not os.path.exists(dst_dir):
-                os.makedirs(dst_dir)
-            for item in os.listdir(src_dir):
-                src = os.path.join(src_dir, item)
-                dst = os.path.join(dst_dir, item)
-                shutil.copyfile(src, dst)
-    
-    def clean_thumbnails():
-        projects = all_project_names(root='')
-        for project in projects:
-            path = pathlib.Path('doc') / project / 'thumbnails'
-            if path.is_dir():
-                print(f'Removing thumbnails folder {path}')
-                shutil.rmtree(path)
-
-    return {
-        'actions': [move_thumbnails],
-        'clean': [clean_thumbnails],
-    }
-
-def task_get_evaluated_doc():
-    """Fetch the evaluated branch and checkout the /doc folder."""
-
-    def clean_doc():
-        doc_dir = pathlib.Path('doc')
-        for subdir in doc_dir.iterdir():
-            if not subdir.is_dir():
-                continue
-            if subdir.name in DEFAULT_DOC_EXCLUDE:
-                continue
-            shutil.rmtree(subdir)
-
-    return {
-        'actions': [
-            # Fetch the evaluated branch containing the evaluated projects
-            'git fetch https://github.com/%(githubrepo)s.git evaluated:refs/remotes/evaluated',
-            # Checkout the doc/ folder from that branch into the current branch
-            'git checkout evaluated -- ./doc',
-            # The previous command stages all what is in doc/, unstage that.
-            # This is better UX when building the site locally, not needed on the CI.
-            'git reset doc/',
-        ],
-        'clean': [clean_doc],
-        'params': [githubrepo_param]
-}
-
-def task_make_assets():
-    """Copy the projects assets to assets/projname/assets/
-    
-    This includes:
-    - the project archive (output of anaconda-project archive)
-      that is in the ./doc/projname/ folder
-    - all the files found in the ./projename/assets/ folder, if it exists.
-
-    TODO
-    nbsite corrects the links to the assets in nbsite_fix_links.py
-    it should not have to do that, instead the assets should be pushed to the
-    docs folder
-    """
-
-    def make_assets(root='', name='all'):
-        if not os.path.exists('assets'):
-            os.mkdir('assets')
-        projects = all_project_names(root) if name == 'all'  else [name]
-        for project in projects:
-            _make_assets(project)
-
-    def _make_assets(name):
-        # Copy all the files in ./projname/assets to ./assets/projname/assets/
-        proj_assets_path = pathlib.Path(name, 'assets')
-        if proj_assets_path.exists():
-            dest_assets_path = pathlib.Path('assets', name, 'assets')
-            if not dest_assets_path.exists():
-                os.makedirs(dest_assets_path)
-            shutil.copytree(proj_assets_path, dest_assets_path, dirs_exist_ok=True)
-
-    def clean_assets():
-        projects = all_project_names(root='')
-        for project in projects:
-            _clean_assets(project)
-        assets_dir = pathlib.Path('assets')
-        remove_empty_dirs(assets_dir)
-        if assets_dir.exists() and not any(assets_dir.iterdir()):
-            print(f'Removing empty dir {assets_dir}')
-            assets_dir.rmdir()
-
-    def _clean_assets(name):
-        assets_dir = pathlib.Path('assets')
-        if not assets_dir.exists():
-            return
-        _archives_dir = pathlib.Path('assets', '_archives')
-        if _archives_dir.exists():
-            archive_path = _archives_dir / f'{name}.zip'
-            if archive_path.exists():
-                print('fRemoving {archive_path}')
-                archive_path.unlink()
-        proj_dir = assets_dir / name
-        if not proj_dir.exists():
-            return
-        project_assets_dir = assets_dir / name / 'assets'
-        if not project_assets_dir.exists():
-            return
-        for asset in project_assets_dir.iterdir():
-            if asset.is_file():
-                asset.unlink()
-            elif asset.is_dir():
-                shutil.rmtree(asset)
-
-    return {
-        'actions': [make_assets],
-        'params': [name_param],
-        'clean': [clean_assets],
-    }
-
-
-def task_remove_doc_not_evaluated():
-    """TEMP task that should be removed when all the projects are on evaluated.
-    """
-
-    def remove():
-        projects = all_project_names(root='')
-        doc_path = pathlib.Path('doc')
-        for project in projects:
-            proj_path = doc_path / project
-            if not proj_path.exists():
-                continue
-            if not any(f.suffix == '.ipynb' for f in proj_path.iterdir()):
-                print(f'Removing {proj_path} as no evaluated notebook found in it')
-                shutil.rmtree(proj_path)
-
-    return {'actions': [remove]}
-
-def task_build_website():
-    """Build website, assumes you are in an environment with required dependencies and have build projects"""
-
-    return {
-        'actions': [
-            "nbsite build --examples .",
-        ],
-        'clean': [
-            'rm -rf builtdocs/',
-            'rm -rf jupyter_execute/',
-            'rm -f doc/*/*.rst',
-            'rm -f doc/index.rst',
-        ]
-    }
-
-def task_index_symlinks():
-    "Create relative symlinks to provide short, convenient project URLS"
-
-    def generate_index_symlinks():
-        cwd = os.getcwd()
-        for name in all_project_names(''):
-            project_path = os.path.abspath(os.path.join('.', 'builtdocs', name))
-            try:
-                os.chdir(project_path)
-                listing = os.listdir(project_path)
-                if 'index.html' not in listing:
-                    os.symlink('./%s.html' % name, './index.html')
-                    print('Created symlink for %s' % name)
-                os.chdir(cwd)
-            except Exception as e:
-                print(str(e))
-        os.chdir(cwd)
-    return {'actions':[generate_index_symlinks]}
-
-
-REDIRECT_TEMPLATE = """
-<!DOCTYPE html>
-<html>
-   <head>
-      <title>{name} redirect</title>
-      <meta http-equiv = "refresh" content = "0; url = https://examples.pyviz.org/{name}/{name}.html" />
-   </head>
-</html>
-"""
-
-
-def task_index_redirects():
-    """
-    Create redirect pages to provide short, convenient project URLS.
-    Should behave the same as task_index_symlinks but can be used where
-    symlinks are not suitable.
-    """
-    def write_redirect(name):
-        with open('./index.html', 'w') as f:
-            contents = REDIRECT_TEMPLATE.format(name=name)
-            f.write(contents)
-            print('Created relative HTML redirect for %s' % name)
-
-    # TODO: known to generate some broken redirects.
-    def generate_index_redirect():
-        cwd = os.getcwd()
-        for name in all_project_names(''):
-            project_path = os.path.abspath(os.path.join('.', 'builtdocs', name))
-            try:
-                os.chdir(project_path)
-                listing = os.listdir(project_path)
-                if 'index.html' not in listing:
-                    write_redirect(name)
-                os.chdir(cwd)
-            except Exception as e:
-                complain(str(e))
-        os.chdir(cwd)
-
-    def clean_index_redirects():
-        for name in all_project_names(''):
-            project_path = pathlib.Path('builtdocs') / name
-            index_path = project_path / 'index.html'
-            if index_path.is_file():
-                print(f'Removing index redirect {index_path}')
-                index_path.unlink()
-
-    return {
-        'actions': [generate_index_redirect],
-        'clean': [clean_index_redirects]
-    }
 
 def print_changes_in_dir(filepath='.diff'):
     """Dumps as JSON a dict of the changed projects and removed projects.
@@ -692,105 +191,143 @@ def print_changes_in_dir(filepath='.diff'):
     print(json.dumps(updates))
 
 
-def task_list_changed_dirs_with_main():
-    """
-    Print the projects that have changes compared to main.
-    """ 
-    return {
-        'actions': [
-            'git fetch origin main',
-            'git diff origin/main %(sha)s --name-only > .diff',
-            print_changes_in_dir,
-        ],
-        'params': [sha_param],
-        'teardown': ['rm -f .diff']
-    }
-
-def task_list_changed_dirs_with_last_commit():
-    """
-    Print the  projects that have changes compared to the last commit.
-    """ 
-    return {
-        'actions': [
-            'git diff HEAD^ HEAD --name-only > .diff',
-            print_changes_in_dir,
-        ],
-        'teardown': ['rm -f .diff']
-    }
-
-# INFO:
-# anaconda-project prepare ... doesn't download the data, instaed it prints "Previously downloaded file located at {abs/to/data}"
-# This is why it makes sense to setup the small test data before running `anaconda-project prepare/run`.
-
-# Potential alternatives to run the tests with nbqa and nbmake (or nbval when 0.9.7/0.10.0 gets released)
-# nbqa flake8 network_packets/network_packets.ipynb
-# pytest --nbmake --nbmake-kernel=test-kernel network_packets/network_packets.ipynb
+def project_has_data_folder(name):
+    """Whether a project has a data folder"""
+    path = pathlib.Path(name) / 'data'
+    if not path.is_dir():
+        return False
+    has_files = not any(path.iterdir())
+    return has_files
 
 
-def should_skip_test(name):
-    skip_test = False
-    if skip_test:
-        print('skip_test: True')
-    return False
-
-    # Prepared for when skip_test is added
+def project_has_no_data_ingestion(name):
+    """Whether a project defines `no_data_ingestion` to True"""
     spec = project_spec(name)
-    skip_test = spec['examples_config'].get('skip_test', False)
-    return skip_test
+    return spec.get('examples_config', {}).get('no_data_ingestion', False)
 
-def task_prepare_project_test():
+
+def project_has_downloads(name):
+    """Whether a project has a non-empty `downloads` section."""
+    spec = project_spec(name)
+    downloads = spec.get('downloads', {})
+    return bool(downloads)
+
+
+def project_has_intake_catalog(name):
+    """Whether a project has an Intake catalog"""
+    path = pathlib.Path(name) / 'catalog.yml'
+    return path.is_file()
+
+
+def project_has_test_catalog(name):
+    """Whether a project has a test catalog"""
+    path = pathlib.Path('test_data') / name / 'catalog.yml'
+    return path.exists()
+
+
+def project_has_test_data(name):
+    """Whether a project has a test data"""
+    path = pathlib.Path('test_data') / name
+    if not path.is_dir():
+        return False
+    has_files = not any(path.iterdir())
+    return has_files
+
+
+def remove_empty_dirs(path):
     """
-    Run `anaconda-project prepare --directory name`,
-
-    This doesn't run if `skip_notebooks_evaluation` is set to True.
+    Remove all the empty dirs in a tree, including the root.
     """
+    # Remove children dirs
+    for root, dirnames, _ in os.walk(path, topdown=False):
+        for dirname in dirnames:
+            p = os.path.realpath(os.path.join(root, dirname))
+            error = False
+            try:
+                os.rmdir(p)
+            except OSError:
+                error = True
+            if not error:
+                print(f'Removed empty dir {p}')
+    # Remove root dir
+    error = False
+    try:
+        os.rmdir(path)
+    except OSError:
+        error = True
+    if not error:
+        print(f'Removed empty dir {path}')
 
-    def prepare_project_test(name):
 
-        data_already_there = []
-        data_path = pathlib.Path(name, 'data')
-        if data_path.is_dir() and any(data_path.iterdir()):
-            data_already_there = list(data_path.rglob('*'))
-        with removing_files([pathlib.Path(name, '.projectignore')]):
-            subprocess.run(
-                ['anaconda-project', 'prepare', '--directory', name, '--env-spec', 'test'],
-                check=True
-            )
-        if data_path.is_dir() and any(data_path.iterdir()):
-            for p in data_path.rglob('*'):
-                if p not in data_already_there and p.is_file():
-                    p.unlink()
-            remove_empty_dirs(data_path)
+@contextlib.contextmanager
+def removing_files(paths):
+    """
+    Context manager to remove a list of files on exit, if they were
+    not already there on enter.
+    """
+    already_there = []
+    for path in paths:
+        already_there.append(path.is_file())
+    yield
+    for path in paths:
+        if path not in already_there:
+            if path.is_file():
+                print(f'Removing {path}')
+                path.unlink()
 
-    for name in all_project_names(root=''):
-        yield {
-            'name': name,
-            'actions': [(prepare_project_test, [name])],
-            'uptodate': [(should_skip_test, [name])],
-            'clean': [f'rm -rf {name}/envs'],
-        }
 
-def task_lint_project():
-    """Run the lint command of a project"""
-    for name in all_project_names(root=''):
-        yield {
-            'name': name,
-            'actions': [
-                f'anaconda-project run --directory {name} lint',
-            ],
-            'uptodate': [(should_skip_test, [name])],
-        }
+def _prepare_paths(root, name, test_data, filename='catalog.yml'):
+    """
+    Return a dict of paths, useful to deal with the test data.
+    """
+    if root == '':
+        root = os.getcwd()
+    root = os.path.abspath(root)
+    test_data = test_data if os.path.isabs(test_data) else os.path.join(root, test_data)
+    test_path = os.path.join(test_data, name)
+    project_path = os.path.join(root, name)
+    return {
+        # Path to the project, e.g. ./projname
+        'project': project_path,
+        # Path to the real data folder, e.g. ./projname/data
+        'real': os.path.join(project_path, 'data'),
+        # Path to the test data folder, e.g. ./test_data/projname
+        'test': test_path,
+        # Path to the real intake catalog, e.g. ./projname/catalog.yml
+        'cat_real': os.path.join(project_path, filename),
+        # Path to the real intake catalog, e.g. ./test_data/projname/catalog.yml
+        'cat_test': os.path.join(test_path, filename),
+        # Path to the temporary intake catalog, e.g. ./projname/tmp_catalog.yml
+        # This is used to store the original catalog
+        'cat_tmp': os.path.join(project_path, 'tmp_' + filename),
+    }
 
-def task_test_project():
-    """Run the test command of a project"""
-    for name in all_project_names(root=''):
-        yield {
-            'name': name,
-            'actions': [
-                f'anaconda-project run --directory {name} test',
-            ],
-            'uptodate': [(should_skip_test, [name])]
-        }
+
+def project_spec(projname, filename='anaconda-project.yml'):
+    """
+    Return the spec of a project.
+    """
+    from yaml import safe_load
+
+    path = pathlib.Path(projname) / filename
+    with open(path, 'r') as f:
+        spec = safe_load(f)
+    return spec
+
+
+def projname_to_servername(name):
+    """
+    Replace '_' by '-'. Assumes projname only has [a-z_]
+    """
+    return name.replace('_', '-')
+
+
+def projname_to_title(name):
+    """
+    Replace '_' by ' ' and apply `.title()`. Assumes projname only has [a-z_]
+    """
+    return name.replace('_', ' ').title()
+
 
 def should_skip_notebooks_evaluation(name):
     """
@@ -806,116 +343,107 @@ def should_skip_notebooks_evaluation(name):
     skip_notebooks_evaluation = spec.get('examples_config', {}).get('skip_notebooks_evaluation', False)
     return skip_notebooks_evaluation
 
-def task_prepare_project():
-    """
-    Run `anaconda-project prepare --directory name`,
 
-    This doesn't run if `skip_notebooks_evaluation` is set to True.
+def should_skip_test(name):
     """
+    Determines whether testing a project should be skipped.
+    """
+    skip_test = False
+    if skip_test:
+        print('skip_test: True')
+    return False
+
+    # TODO: remove it if not needed
+    # Prepared for when skip_test is added
+    spec = project_spec(name)
+    skip_test = spec['examples_config'].get('skip_test', False)
+    return skip_test
+
+
+
+############# TASKS #############
+
+#### Utils tasks ####
+
+
+def task_util_last_commit_date():
+    """
+    Print the last committer date.
+    """
+
     for name in all_project_names(root=''):
         yield {
             'name': name,
-            'actions': [
-                f'anaconda-project prepare --directory {name}',
-            ],
-            'uptodate': [(should_skip_notebooks_evaluation, [name])],
-            # TODO
-            'clean': [f'git clean -fxd {name}'],
+            'actions': [(last_commit_date, [name])]
         }
 
-def task_process_notebooks():
+
+def task_util_list_changed_dirs_with_main():
     """
-    Process notebooks.
+    Print the projects that changed compared to main
+    """ 
+    return {
+        'actions': [
+            'git fetch origin main',
+            'git diff origin/main %(sha)s --name-only > .diff',
+            print_changes_in_dir,
+        ],
+        'params': [sha_param],
+        'teardown': ['rm -f .diff']
+    }
 
-    If the project has not set `skip_notebooks_evaluation` to True then
-    run notebooks and save their evaluated version in doc/{name}.
-    This is expected to be executed from an environment outside of the 
-    target environment (i.e. the one running the notebooks).
 
-    Otherwise simply copy the notebooks to doc/{name}.
+def task_list_changed_dirs_with_last_commit():
     """
+    Print the projects that changed compared to the last commit.
+    """ 
+    return {
+        'actions': [
+            'git diff HEAD^ HEAD --name-only > .diff',
+            print_changes_in_dir,
+        ],
+        'teardown': ['rm -f .diff']
+    }
 
-    def run_notebook(src_path, dst_path, kernel_name, dir_name):
-        """
-        Run a notebook using nbclient.
-        """
-        import nbformat
-        from nbclient import NotebookClient
 
-        print(f'Reading notebook {src_path}')
-        nb = nbformat.read(src_path, as_version=4)
-        client = NotebookClient(
-            nb,
-            timeout=NOTEBOOK_EVALUATION_TIMEOUT,
-            kernel_name=kernel_name,
-            resources={'metadata': {'path': f'{dir_name}/'}},
-        )
-        print(f'Executing notebook {src_path} with kernel {kernel_name} in dir {dir_name}')
-        client.execute()
-        print(f'Saving notebook at {dst_path}')
-        # nbsite takes care of copying json files generated by HoloViews/Panel.
-        # TODO: make sure this is doing the same thing.
-        nbformat.write(nb, dst_path)
-
-    def run_notebooks(name):
-        """
-        Run notebooks found in the project folder with the {name}-kernel
-        IPykernel and save them in the doc/{name} folder.
-        """
-        notebooks = find_notebooks(name)
-        for notebook in notebooks:
-            out_dir = pathlib.Path('doc') / name
-            if not out_dir.exists():
-                out_dir.mkdir()
-            run_notebook(
-                src_path=notebook,
-                dst_path=out_dir / notebook.name,
-                kernel_name=f'{name}-kernel',
-                dir_name=name,
-            )
+def task_util_list_comma_separated_projects():
+    """Print a list of projects found in .projects
     
-    def copy_notebooks(name):
-        """
-        Copy notebooks from the project folder to the doc/{name} folder.
-        """
-        # TODO: should it also copy .json files?
-        notebooks = find_notebooks(name)
-        for notebook in notebooks:
-            out_dir = pathlib.Path('doc') / name
-            if not out_dir.exists():
-                out_dir.mkdir()
-            dst = out_dir / notebook.name
-            print(f'Copying notebook {notebook} to {dst}')
-            shutil.copyfile(notebook, dst)
+    They are expected to be comma separated.
+    """
 
-    for name in all_project_names(root=''):
-        skip_notebooks_evaluation = should_skip_notebooks_evaluation(name)
-        if not skip_notebooks_evaluation:
-            actions = [
-                f'echo "install kernel {name}-kernel"',
-                # Setup Kernel
-                f'conda run --prefix {name}/envs/default python -m ipykernel install --user --name={name}-kernel',
-                # Run notebooks with that kernel
-                (run_notebooks, [name]),
-            ]
-            teardown = [
-                f'echo "remove kernel {name}-kernel"',
-                # Remove Kernel
-                f'conda run --prefix {name}/envs/default jupyter kernelspec remove {name}-kernel -f',
-            ]
-        else:
-            actions = [
-                f'echo "Skipping running notebooks of {name}"',
-                (copy_notebooks, [name]),
-            ]
-            teardown = []
-        yield {
-            'name': name,
-            'actions': actions,
-            'teardown': teardown,
-            # TODO
-            'clean': [f'git clean -fxd doc/{name}'],
-        }
+    def list_comma_separated_projects(file='.projects'):
+        file = pathlib.Path(file)
+        if not file.exists():
+            raise FileNotFoundError(f'File {file} not found')
+        projects = file.read_text().strip()
+        if not projects:
+            raise ValueError(f'Missing comma separated projects in {file}')
+        projects = projects.split(',')
+        all_projects = all_project_names(root='')
+        for project in projects:
+            if project not in all_projects:
+                raise ValueError(f'Listed project {project} not found, check its name.')
+        print(projects)
+
+    return {
+        'actions': [list_comma_separated_projects],
+    }
+
+
+def task_util_list_project_dir_names():
+    """Print a list of all the project directory names"""
+
+    def list_project_dir_names():
+        print(all_project_names(root=''))
+
+    return {
+        'actions': [list_project_dir_names],
+    }
+
+#### Validate ####
+
+
 
 def task_validate_project_file():
     """Validate the existence and content of the anaconda-project.yml file"""
@@ -1084,29 +612,6 @@ def task_validate_intake_catalog():
             'actions': [(validate_intake_catalog, [name])],
         }
 
-def project_has_downloads(name):
-    """Whether a project has a non-empty `downloads` section."""
-    spec = project_spec(name)
-    downloads = spec.get('downloads', {})
-    return bool(downloads)
-
-def project_has_intake_catalog(name):
-    """Whether a project has an Intake catalog"""
-    path = pathlib.Path(name) / 'catalog.yml'
-    return path.is_file()
-
-def project_has_data_folder(name):
-    """Whether a project has a data folder"""
-    path = pathlib.Path(name) / 'data'
-    if not path.is_dir():
-        return False
-    has_files = not any(path.iterdir())
-    return has_files
-
-def project_has_no_data_ingestion(name):
-    """Whether a project defines `no_data_ingestion` to True"""
-    spec = project_spec(name)
-    return spec.get('examples_config', {}).get('no_data_ingestion', False)
 
 def task_validate_data_sources():
     """Validate the data sources of a project
@@ -1175,18 +680,6 @@ def task_validate_data_sources():
             'actions': [(validate_data_sources, [name])],
         }
 
-def project_has_test_data(name):
-    """Whether a project has a test data"""
-    path = pathlib.Path('test_data') / name
-    if not path.is_dir():
-        return False
-    has_files = not any(path.iterdir())
-    return has_files
-
-def project_has_test_catalog(name):
-    """Whether a project has a test catalog"""
-    path = pathlib.Path('test_data') / name / 'catalog.yml'
-    return path.exists()
 
 def task_validate_small_test_data():
     """Validate the small test data of a project, if relevant.
@@ -1282,24 +775,6 @@ def task_validate_notebook_header():
             'actions': [(validate_notebook_header, [name])],
         }
 
-def get_png_dims(fname):
-    """
-    From https://stackoverflow.com/a/20380514/10875966
-    """
-    with open(fname, 'rb') as fhandle:
-        head = fhandle.read(24)
-        if len(head) != 24:
-            raise ValueError
-        imgtype = imghdr.what(fname)
-        if imghdr.what(fname) == 'png':
-            check = struct.unpack('>i', head[4:8])[0]
-            if check != 0x0d0a1a0a:
-                return
-            width, height = struct.unpack('>ii', head[16:24])
-        else:
-            raise ValueError(f'Only supports PNG, not {imgtype}')
-        return width, height
-
 
 def task_validate_thumbnails():
     """Validated that the project has a thumbnail and that it's correct.
@@ -1348,18 +823,640 @@ def task_validate_thumbnails():
             'actions': [(validate_thumbnails, [name])],
         }
 
-### Grouped tasks
+
+#### Test ###
+
+def task_test_small_data_setup():
+    """Copy small versions of the data from test_data/
+    
+    Small test data is available when a folder with the same name as the
+    project's folder name is found in the `./test_data/` folder (it must
+    include some files).
+
+    If the project depends on an Intake catalog, and `./test_data/` contains
+    an Intake catalog, the project's catalog will be temporarily replaced
+    by the test catalog.
+
+    All the data found in the `./test_data/projname/` folder, but the Intake
+    catalog if any,  will be copied over to the `./projname/data/` folder.
+
+    IMPORTANT: Test data for one project can depend on test data of another
+    project (e.g. via relative links in the intake catalog). This does not
+    affect the implementation of this task, but is worth noting.
+    """
+
+    def copy_test_data(name, root='', test_data='test_data', cat_filename='catalog.yml'):
+        paths = _prepare_paths(root, name, test_data, cat_filename)
+
+        # Not small test data found, nothing to copy.
+        if not os.path.exists(paths['test']):
+            return
+
+        has_test_catalog = os.path.exists(paths['cat_test'])
+
+        if has_test_catalog:
+            print('* Copying intake catalog ...')
+
+            # move real catalog file to tmp if tmp doesn't exist
+            if os.path.exists(paths['cat_tmp']):
+                raise ValueError(
+                    "Fail: Temp file already exists - try "
+                    f"'doit clean small_data_setup:{name}'"
+                )
+            os.rename(paths['cat_real'], paths['cat_tmp'])
+
+            # move test catalog to project directory
+            shutil.copyfile(paths['cat_test'], paths['cat_real'])
+            print(f"  Intake catalog successfully copied from {paths['cat_test']} to {paths['cat_real']}")
+
+        if (os.path.exists(paths['test'])
+            and os.listdir(paths['test']) == ['catalog.yml']):
+            # The only data was the catalog, that has already been processed.
+            return
+
+        print('* Copying test data ...')
+        if os.path.exists(paths['real']):
+            raise FileExistsError(
+                f"Found unexpected {paths['real']}, run "
+                f"'doit clean small_data_setup:{name}'"
+            )
+
+        ignore_catalog = shutil.ignore_patterns('catalog.yml')
+        shutil.copytree(paths['test'], paths['real'], ignore=ignore_catalog)
+        print(f"  Test data sucessfully copied from {paths['test']} to {paths['real']}")
+
+    def remove_test_data(name, root='', test_data='test_data', cat_filename='catalog.yml'):
+        paths = _prepare_paths(root, name, test_data, cat_filename)
+
+        # No small test data found, no need to clean anything.
+        if not os.path.exists(paths['test']):
+            return
+
+        if os.path.exists(paths['cat_real']):
+            print("* Replacing intake catalog ...")
+
+            if not os.path.exists(paths['cat_tmp']):
+                print("Nothing to do: No temp file found. Use git status to "
+                      f"check that you have the real catalog at {paths['cat_real']}")
+            else:
+                os.remove(paths['cat_real'])
+                os.rename(paths['cat_tmp'], paths['cat_real'])
+                print('  Intake catalog successfully cleaned')
+
+        print('* Removing test data ...')
+
+        if not os.path.exists(paths['real']):
+            print('  No data to remove')
+            return
+        elif not os.listdir(paths['real']):
+            os.rmdir(paths['real'])
+            print(f"  No data found in {paths['real']}, just removed empty dir")
+        else:
+            shutil.rmtree(paths['real'])
+            print(f"  Test data successfully removed from {paths['real']}")
+
+    for name in all_project_names(root=''):
+        yield {
+            'name': name,
+            'actions': [(copy_test_data, [name])],
+            'clean': [(remove_test_data, [name])],
+        }
+
+
+def task_test_prepare_project():
+    """
+    Run `anaconda-project prepare --directory name --env-spec test`
+
+    `anaconda-project prepare ...` doesn't download the data is already there.
+    Instead it prints "Previously downloaded file located at {abs/to/data}"
+    This is why it makes sense to setup the small test data before running
+    `anaconda-project prepare/run`.
+
+    # TODO: remove if not needed
+    This doesn't run if `skip_test` is set to True.
+    """
+
+    def prepare_project_test(name):
+
+        data_already_there = []
+        data_path = pathlib.Path(name, 'data')
+        if data_path.is_dir() and any(data_path.iterdir()):
+            data_already_there = list(data_path.rglob('*'))
+        with removing_files([pathlib.Path(name, '.projectignore')]):
+            subprocess.run(
+                ['anaconda-project', 'prepare', '--directory', name, '--env-spec', 'test'],
+                check=True
+            )
+        if data_path.is_dir() and any(data_path.iterdir()):
+            for p in data_path.rglob('*'):
+                if p not in data_already_there and p.is_file():
+                    p.unlink()
+            remove_empty_dirs(data_path)
+
+    for name in all_project_names(root=''):
+        yield {
+            'name': name,
+            'actions': [(prepare_project_test, [name])],
+            'uptodate': [(should_skip_test, [name])],
+            'clean': [f'rm -rf {name}/envs'],
+        }
+
+
+def task_test_lint_project():
+    """Run the lint command of a project
+    
+    Alternatively we could run nbqa installed globally instead of having
+    to rely on a specific version of nbsmoke installed in each project. E.g.:
+
+        nbqa flake8 network_packets/network_packets.ipynb
+    """
+    for name in all_project_names(root=''):
+        yield {
+            'name': name,
+            'actions': [
+                f'anaconda-project run --directory {name} lint',
+            ],
+            'uptodate': [(should_skip_test, [name])],
+        }
+
+
+def task_test_project():
+    """Run the test command of a project
+    
+    Potential alternatives to run the tests with nbmake or nbval, from outside
+    the environment. E.g.
+
+        pytest --nbmake --nbmake-kernel=test-kernel network_packets/network_packets.ipynb
+    """
+    for name in all_project_names(root=''):
+        yield {
+            'name': name,
+            'actions': [
+                f'anaconda-project run --directory {name} test',
+            ],
+            'uptodate': [(should_skip_test, [name])]
+        }
+
+
+#### Build ####
+
+
+def task_build_prepare_project():
+    """
+    Run `anaconda-project prepare --directory 
+
+    This doesn't run if `skip_notebooks_evaluation` is set to True.
+    """
+    for name in all_project_names(root=''):
+        yield {
+            'name': name,
+            'actions': [
+                f'anaconda-project prepare --directory {name}',
+            ],
+            'uptodate': [(should_skip_notebooks_evaluation, [name])],
+            # TODO
+            'clean': [f'git clean -fxd {name}'],
+        }
+
+
+def task_build_process_notebooks():
+    """
+    Process notebooks.
+
+    If the project has not set `skip_notebooks_evaluation` to True then
+    run notebooks and save their evaluated version in doc/{projname}/.
+    This is expected to be executed from an environment outside of the 
+    target environment.
+    Otherwise simply copy the notebooks to doc/{projname}/.
+    """
+
+    def run_notebook(src_path, dst_path, kernel_name, dir_name):
+        """
+        Run a notebook using nbclient.
+        """
+        import nbformat
+        from nbclient import NotebookClient
+
+        print(f'Reading notebook {src_path}')
+        nb = nbformat.read(src_path, as_version=4)
+        client = NotebookClient(
+            nb,
+            timeout=NOTEBOOK_EVALUATION_TIMEOUT,
+            kernel_name=kernel_name,
+            resources={'metadata': {'path': f'{dir_name}/'}},
+        )
+        print(f'Executing notebook {src_path} with kernel {kernel_name} in dir {dir_name}')
+        client.execute()
+        print(f'Saving notebook at {dst_path}')
+        # nbsite takes care of copying json files generated by HoloViews/Panel.
+        # TODO: make sure this is doing the same thing.
+        nbformat.write(nb, dst_path)
+
+    def run_notebooks(name):
+        """
+        Run notebooks found in the project folder with the {name}-kernel
+        IPykernel and save them in the doc/{name} folder.
+        """
+        notebooks = find_notebooks(name)
+        for notebook in notebooks:
+            out_dir = pathlib.Path('doc') / name
+            if not out_dir.exists():
+                out_dir.mkdir()
+            run_notebook(
+                src_path=notebook,
+                dst_path=out_dir / notebook.name,
+                kernel_name=f'{name}-kernel',
+                dir_name=name,
+            )
+    
+    def copy_notebooks(name):
+        """
+        Copy notebooks from the project folder to the doc/{name} folder.
+        """
+        # TODO: should it also copy .json files?
+        notebooks = find_notebooks(name)
+        for notebook in notebooks:
+            out_dir = pathlib.Path('doc') / name
+            if not out_dir.exists():
+                out_dir.mkdir()
+            dst = out_dir / notebook.name
+            print(f'Copying notebook {notebook} to {dst}')
+            shutil.copyfile(notebook, dst)
+
+    for name in all_project_names(root=''):
+        skip_notebooks_evaluation = should_skip_notebooks_evaluation(name)
+        if not skip_notebooks_evaluation:
+            actions = [
+                f'echo "install kernel {name}-kernel"',
+                # Setup Kernel
+                f'conda run --prefix {name}/envs/default python -m ipykernel install --user --name={name}-kernel',
+                # Run notebooks with that kernel
+                (run_notebooks, [name]),
+            ]
+            teardown = [
+                f'echo "remove kernel {name}-kernel"',
+                # Remove Kernel
+                f'conda run --prefix {name}/envs/default jupyter kernelspec remove {name}-kernel -f',
+            ]
+        else:
+            actions = [
+                f'echo "Skipping running notebooks of {name}"',
+                (copy_notebooks, [name]),
+            ]
+            teardown = []
+        yield {
+            'name': name,
+            'actions': actions,
+            'teardown': teardown,
+            # TODO
+            'clean': [f'git clean -fxd doc/{name}'],
+        }
+
+
+#### Doc ####
+
+
+def task_doc_archive_projects():
+    """Archive projects to assets/_archives"""
+
+    def archive_project(root='', name='all'):
+        projects = all_project_names(root) if name == 'all'  else [name]
+        for project in projects:
+            _archive_project(project)
+
+    def _archive_project(project):
+        from yaml import safe_dump
+
+
+        has_project_ignore = False
+        projectignore_path = pathlib.Path(project, '.projectignore')
+        if projectignore_path.exists():
+            has_project_ignore = True
+
+        has_readme = False
+        readme_path = pathlib.Path(project, 'README.md')
+        if readme_path.exists():
+            has_readme = True
+
+        print(f'Archiving {project}...')
+        if not os.path.exists(readme_path):
+            shutil.copyfile('README.md', readme_path)
+
+        # stripping extra fields out of anaconda_project to make them more legible
+        path = os.path.join(project, 'anaconda-project.yml')
+        tmp_path = f'{project}_anaconda-project.yml'
+        shutil.copyfile(path, tmp_path)
+        spec = project_spec(project)
+
+        # special field that anaconda-project doesn't know about
+        spec.pop('examples_config', '')
+        spec.pop('user_fields', '')
+
+        # commands and envs that users don't need
+        spec['commands'].pop('test', '')
+        spec['commands'].pop('lint', '')
+        spec['env_specs'].pop('test', '')
+
+        # get rid of any empty fields
+        spec = {k: v for k, v in spec.items() if bool(v)}
+
+        with open(path, 'w') as f:
+            safe_dump(spec, f, default_flow_style=False, sort_keys=False)
+
+        archives_path = os.path.join('assets', '_archives')
+        if not os.path.exists(archives_path):
+            os.makedirs(archives_path)
+
+        subprocess.run(
+            ["anaconda-project", "archive", "--directory", f"{project}", f"assets/_archives/{project}.zip"],
+            check=True
+        )
+        shutil.copyfile(tmp_path, path)
+        os.remove(tmp_path)
+
+        if not has_project_ignore:
+            print(f'Removing temp {projectignore_path}')
+            projectignore_path.unlink()
+        if not has_readme:
+            print(f'Removing temp {readme_path}')
+            readme_path.unlink()
+
+    def clean_archive():
+        projects = all_project_names(root='')
+        for project in projects:
+            _clean_archive(project)
+        assets_path = pathlib.Path('assets')
+        remove_empty_dirs(assets_path)
+
+    def _clean_archive(project):
+        _archives_path = pathlib.Path('assets', '_archives')
+        if not _archives_path.exists():
+            return
+        archive_path = _archives_path / f'{project}.zip'
+        print(f'Removing {archive_path}')
+        archive_path.unlink(archive_path)
+
+    return {
+        'actions': [archive_project],
+        'params': [name_param],
+        'clean': [clean_archive]
+    }
+
+
+def task_doc_move_thumbnails():
+    """Move thumbnails from the project dir to the project doc dir"""
+
+    def move_thumbnails(root='', name='all'):
+        projects = all_project_names(root) if name == 'all'  else [name]
+        for project in projects:
+            _move_thumbnails(project)
+
+    def _move_thumbnails(name):
+        src_dir = os.path.join(name, 'thumbnails')
+        dst_dir = os.path.join('doc', name, 'thumbnails')
+        if os.path.exists(src_dir):
+            if not os.path.exists(dst_dir):
+                print(f'Creating directories {dst_dir}')
+                os.makedirs(dst_dir)
+            for item in os.listdir(src_dir):
+                src = os.path.join(src_dir, item)
+                dst = os.path.join(dst_dir, item)
+                print(f'Copying thumbnail {src} to {dst}')
+                shutil.copyfile(src, dst)
+    
+    def clean_thumbnails():
+        projects = all_project_names(root='')
+        for project in projects:
+            path = pathlib.Path('doc') / project / 'thumbnails'
+            if path.is_dir():
+                print(f'Removing thumbnails folder {path}')
+                shutil.rmtree(path)
+
+    return {
+        'actions': [move_thumbnails],
+        'clean': [clean_thumbnails],
+    }
+
+
+def task_doc_move_assets():
+    """Copy the projects assets to assets/projname/assets/
+    
+    This includes:
+    - the project archive (output of anaconda-project archive)
+      that is in the ./doc/projname/ folder
+    - all the files found in the ./projename/assets/ folder, if it exists.
+
+    TODO
+    nbsite corrects the links to the assets in nbsite_fix_links.py
+    it should not have to do that, instead the assets should be pushed to the
+    docs folder
+    """
+
+    def move_assets(root='', name='all'):
+        if not os.path.exists('assets'):
+            print('Creating assets/ dir')
+            os.mkdir('assets')
+        projects = all_project_names(root) if name == 'all'  else [name]
+        for project in projects:
+            _move_assets(project)
+
+    def _move_assets(name):
+        # Copy all the files in ./projname/assets to ./assets/projname/assets/
+        proj_assets_path = pathlib.Path(name, 'assets')
+        if proj_assets_path.exists():
+            dest_assets_path = pathlib.Path('assets', name, 'assets')
+            if not dest_assets_path.exists():
+                print(f'Creating dirs {dest_assets_path}')
+                os.makedirs(dest_assets_path)
+            print('Copying tree {proj_assets_path} to {dest_assets_path}')
+            shutil.copytree(proj_assets_path, dest_assets_path, dirs_exist_ok=True)
+
+    def clean_assets():
+        projects = all_project_names(root='')
+        for project in projects:
+            _clean_assets(project)
+        assets_dir = pathlib.Path('assets')
+        remove_empty_dirs(assets_dir)
+        if assets_dir.exists() and not any(assets_dir.iterdir()):
+            print(f'Removing empty dir {assets_dir}')
+            assets_dir.rmdir()
+
+    def _clean_assets(name):
+        assets_dir = pathlib.Path('assets')
+        if not assets_dir.exists():
+            return
+        _archives_dir = pathlib.Path('assets', '_archives')
+        if _archives_dir.exists():
+            archive_path = _archives_dir / f'{name}.zip'
+            if archive_path.exists():
+                print(f'Removing {archive_path}')
+                archive_path.unlink()
+        proj_dir = assets_dir / name
+        if not proj_dir.exists():
+            return
+        project_assets_dir = assets_dir / name / 'assets'
+        if not project_assets_dir.exists():
+            return
+        for asset in project_assets_dir.iterdir():
+            if asset.is_file():
+                print(f'Removing asset {asset}')
+                asset.unlink()
+            elif asset.is_dir():
+                print(f'Removing empty dir {asset}')
+                shutil.rmtree(asset)
+
+    return {
+        'actions': [move_assets],
+        'params': [name_param],
+        'clean': [clean_assets],
+    }
+
+
+def task_doc_get_evaluated():
+    """Fetch the evaluated branch and checkout the /doc folder"""
+
+    def clean_doc():
+        doc_dir = pathlib.Path('doc')
+        for subdir in doc_dir.iterdir():
+            if not subdir.is_dir():
+                continue
+            if subdir.name in DEFAULT_DOC_EXCLUDE:
+                continue
+            print(f'Removing tree {subdir}')
+            shutil.rmtree(subdir)
+
+    return {
+        'actions': [
+            # Fetch the evaluated branch containing the evaluated projects
+            'git fetch https://github.com/%(githubrepo)s.git evaluated:refs/remotes/evaluated',
+            # Checkout the doc/ folder from that branch into the current branch
+            'git checkout evaluated -- ./doc',
+            # The previous command stages all what is in doc/, unstage that.
+            # This is better UX when building the site locally, not needed on the CI.
+            'git reset doc/',
+        ],
+        'clean': [clean_doc],
+        'params': [githubrepo_param]
+}
+
+
+def task_doc_remove_not_evaluated():
+    """TEMP! task that should be removed when all the projects are on evaluated
+
+    TODO: remove it when no longer required.
+    """
+
+    def remove():
+        projects = all_project_names(root='')
+        doc_path = pathlib.Path('doc')
+        for project in projects:
+            proj_path = doc_path / project
+            if not proj_path.exists():
+                continue
+            if not any(f.suffix == '.ipynb' for f in proj_path.iterdir()):
+                print(f'Removing {proj_path} as no evaluated notebook found in it')
+                shutil.rmtree(proj_path)
+
+    return {'actions': [remove]}
+
+
+def task_doc_build_website():
+    """Build website with nbsite.
+    
+    It assumes you are in an environment with required dependencies and
+    the projects have been built.
+    """
+
+    return {
+        'actions': [
+            "nbsite build --examples .",
+        ],
+        'clean': [
+            'rm -rf builtdocs/',
+            'rm -rf jupyter_execute/',
+            'rm -f doc/*/*.rst',
+            'rm -f doc/index.rst',
+        ]
+    }
+
+
+def task_doc_index_redirects():
+    """
+    Create redirect pages to provide short, convenient project URLS.
+
+    E.g. examples.pyviz.org/projname
+    
+    A previous approach was using symlinks and this should behave the same 
+    but can be used where symlinks are not suitable.
+    https://github.com/pyviz-topics/examples/blob/17a17be1a1b159095be55801202741e049a780e8/dodo.py#L281-L298
+    """
+
+    REDIRECT_TEMPLATE = """
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>{name} redirect</title>
+        <meta http-equiv = "refresh" content = "0; url = https://examples.pyviz.org/{name}/{name}.html" />
+    </head>
+    </html>
+    """
+
+    def write_redirect(name):
+        with open('./index.html', 'w') as f:
+            contents = textwrap.dedent(REDIRECT_TEMPLATE.format(name=name))
+            f.write(contents)
+            print('Created relative HTML redirect for %s' % name)
+
+    # TODO: known to generate some broken redirects.
+    def generate_index_redirect():
+        cwd = os.getcwd()
+        for name in all_project_names(''):
+            project_path = os.path.abspath(os.path.join('.', 'builtdocs', name))
+            try:
+                os.chdir(project_path)
+                listing = os.listdir(project_path)
+                if 'index.html' not in listing:
+                    write_redirect(name)
+                os.chdir(cwd)
+            except Exception as e:
+                complain(str(e))
+        os.chdir(cwd)
+
+    def clean_index_redirects():
+        for name in all_project_names(''):
+            project_path = pathlib.Path('builtdocs') / name
+            index_path = project_path / 'index.html'
+            if index_path.is_file():
+                print(f'Removing index redirect {index_path}')
+                index_path.unlink()
+
+    return {
+        'actions': [generate_index_redirect],
+        'clean': [clean_index_redirects]
+    }
+
+
+#### Grouped tasks ####
+
+# These tasks are not meant to be used on the CI (except for cleaning),
+# where it's better to call each task individually as it's then easier to
+# identify which one failed and why.
+# They are more meant to be used by people building and maintaining projects,
+# as a quick way to run multiple tasks at once.
 
 def task_validate():
     """
-    Validate a project, including:
+    Validate a project (doit validate:projname)
+
+    This includes:
     - the existence and content of the anaconda-project.yml file
-    - the existence of a lock file and its state
+    - the existence of a lock file and that is not stale
     - if there is an intake catalog, that it is named correctly
     - the definition of the project's data sources
     - the existence of small test data, if relevant
-    - notebook name
-    - thumbnails
+    - the notebook names
+    - the notebooks have a header
+    - the thumbnails existence and dimensions
     """
     for name in all_project_names(root=''):
         yield {
@@ -1379,82 +1476,64 @@ def task_validate():
 
 def task_test():
     """
-    Test a project, including:
+    Test a project (doit test:projname)
+
+    This includes:
     - setting up the small data
     - preparing the project
     - running the project lint command
     - running the project test command
+
+
+    Run the following command to clean the outputs:
+        doit clean --clean-dep test:projname
     """
     for name in all_project_names(root=''):
         yield {
             'name': name,
         'actions': None,
             'task_dep': [
-                f'small_data_setup:{name}',
-                f'prepare_project_test:{name}',
-                f'lint_project:{name}',
+                f'test_small_data_setup:{name}',
+                f'test_prepare_project:{name}',
+                f'test_lint_project:{name}',
                 f'test_project:{name}',
             ]
         }
 
-def task_validate_and_test():
-    """Validate and test a project."""
-    for name in all_project_names(root=''):
-        yield {
-            'name': name,
-            'actions': None,
-            'task_dep': [
-                f'validate:{name}',
-                f'test:{name}',
-            ]
-        }
 
 def task_build():
     """
-    Build a project in one command.
-
-        doit build:boids
+    Build a project (doit build:projname)
     
     Run the following command to clean the outputs:
-
-        doit clean --clean-dep build:boids
+        doit clean --clean-dep build:projname
     """
     for name in all_project_names(root=''):
         yield {
             'name': name,
             'actions': None,
             'task_dep': [
-                f'prepare_project:{name}',
-                f'process_notebooks:{name}',
+                f'build_prepare_project:{name}',
+                f'build_process_notebooks:{name}',
             ]
         }
 
-def task_website():
+def task_doc():
     """
-    Run subtasks to build the site entirely.
+    Build the doc (doit doc)
 
-        doit website
-    
     Run the following command to clean the outputs:
-
-        doit clean --clean-dep website
+        doit clean --clean-dep doc
     """
     return {
         'actions': None,
         'task_dep': [
-            'archive_project',
-            'move_thumbnails',
-            'make_assets',
-            'get_evaluated_doc',
-            'remove_doc_not_evaluated',
-            'build_website',
-            'index_redirects',
+            'doc_archive_project',
+            'doc_move_thumbnails',
+            'doc_move_assets',
+            'doc_get_evaluated',
+            'doc_remove_not_evaluated',
+            'doc_build_website',
+            'doc_index_redirects',
         ]
     }
-
-def task_add_header():
-    # TODO: Prepare page header with authors, created, last modified, download archive, deployments, share on twitter/linkedin, more?
-    pass
-
-
-# TODO: Add tasks that verify things like the archives, the deployments, etc.

--- a/dodo.py
+++ b/dodo.py
@@ -1446,7 +1446,6 @@ def task_website():
             'move_thumbnails',
             'make_assets',
             'get_evaluated_doc',
-            'make_assets',
             'remove_doc_not_evaluated',
             'build_website',
             'index_redirects',

--- a/dodo.py
+++ b/dodo.py
@@ -27,9 +27,8 @@ DEFAULT_EXCLUDE = [
 ]
 
 DEFAULT_DOC_EXCLUDE = [
-    'assets',
-    *glob.glob( '.*'),
-    *glob.glob( '_*'),
+    '_static',
+    '_templates',
 ]
 
 NOTEBOOK_EVALUATION_TIMEOUT = 3600  # 1 hour, in seconds.
@@ -470,7 +469,7 @@ def task_get_evaluated_doc():
 
     def clean_doc():
         doc_dir = pathlib.Path('doc')
-        for subdir in doc_dir.glob('*/'):
+        for subdir in doc_dir.iterdir():
             if not subdir.is_dir():
                 continue
             if subdir.name in DEFAULT_DOC_EXCLUDE:
@@ -569,6 +568,8 @@ def task_remove_doc_not_evaluated():
         doc_path = pathlib.Path('doc')
         for project in projects:
             proj_path = doc_path / project
+            if not proj_path.exists():
+                continue
             if not any(f.suffix == '.ipynb' for f in proj_path.iterdir()):
                 print(f'Removing {proj_path} as no evaluated notebook found in it')
                 shutil.rmtree(proj_path)
@@ -1442,6 +1443,7 @@ def task_website():
         'actions': None,
         'task_dep': [
             'archive_project',
+            'move_thumbnails',
             'make_assets',
             'get_evaluated_doc',
             'make_assets',

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,6 @@
 #!/bin/bash
 pip install pyctdev
-doit small_data_setup
+doit test_small_data_setup
 rm dodo.py
 rm tox.ini
 rm -rf test_data

--- a/template/anaconda-project.yml
+++ b/template/anaconda-project.yml
@@ -1,19 +1,37 @@
 # To reproduce: install 'anaconda-project', then 'anaconda-project run'
-name: NAME
-description: DESC
+name: "NAME"
+description: "DESC"
+
 examples_config:
   #### REQUIRED ###
   created: YYYY-MM-DD
   maintainers:
-    - MAINTAINER
+    - "MAINTAINER"
   # List of labels displayed in the project card
   # Each label must be a name (e.g. panel) that
   # refers to a SVG badge located in doc/_static/labels
   # (e.g. doc/_static/labels/panel.svg)
   labels:
-    - label1
-    - label2
+    - "label1"
+    - "label2"
+  
   ### OPTIONAL ###
+  # Listed deployments will by default automatically be started.
+  # Maximum number of deployments is 2.
+  # Each deployment must declare the command it deploys, options
+  # include "notebook" or "dashboard".
+  deployments:
+    # Will be deployed at {projname_with_hyphens}-notebook.pyviz.demo.anaconda.com
+    - command: "notebook"
+    # Will be deployed at {projname_with_hyphens}.pyviz.demo.anaconda.com
+    - command: "dashboard"
+      # [optional] Set the AE5 container resource profile.
+      # Options include: "default", "medium" (default), "large"
+      resource_profile: "medium"
+      # [optional] Automatically start the deployment on AE5 when a PR
+      # modifying the project is merged. Default is true.
+      auto_deploy: true
+
   # to build the website (e.g. too long or require too much data).
   # This indicates the system not to run them.
   skip_notebooks_evaluation: false


### PR DESCRIPTION
This PR adds the machinery (relies on a non yet merged branch of *nbsite*) to add a metadata block at the beginning of each notebook page, that metadata being pulled from the *anaconda-project.yml* file.

![image](https://user-images.githubusercontent.com/35924738/212989432-3a9f165f-68cc-4049-899d-a4ae8160083a.png)

Previously deployments were looked for by *nbsite*, by hitting potential endpoints and adding those that respond successfully. Instead of doing that a scheme is added to the `examples_config` entry to define the deployments. The metadata header will rely on that info to add or not links to the deployments.

```yaml
  deployments:
    # Will be deployed at {projname_with_hyphens}-notebook.pyviz.demo.anaconda.com
    - command: "notebook"
    # Will be deployed at {projname_with_hyphens}.pyviz.demo.anaconda.com
    - command: "dashboard"
      # [optional] Set the AE5 container resource profile.
      # Options include: "default", "medium" (default), "large"
      resource_profile: "medium"
      # [optional] Automatically start the deployment on AE5 when a PR
      # modifying the project is merged. Default is true.
      auto_deploy: true
```

This PR also reworked on the assets are handled. The temporary assets folder (created by tasks, and then copied by *nbsite* to `buitdocs/`. It has this structure:
- `assets`
  - `_archives`: project archives (e.g. boids.zip, ...)
  - `projectname`:
    - `assets`: assets (e.g. screenshot.png)

It would be nice not to have to deal with the assets at all and delegate all to Sphinx. I did find a way to delegate the project archives to Sphinx using the `download:` role, but its UI was pretty bad so I reverted that. But I didn't find a way to handle the *assets* a project may have.

The changes made to the assets avoid name clashes, as assets were all copied to a flat directory.