### PR TITLE
anndata_diffex: cache the result of an expensive step

### DIFF
--- a/anndata_diffex/anndata_diffex.ipynb
+++ b/anndata_diffex/anndata_diffex.ipynb
@@ -291,13 +291,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "092479f9-ea6a-4a58-8db0-9c2544090a13",
+   "id": "b6d11d0d",
    "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
-    "# Run differential expression analysis\n",
-    "brca_ds.deseq2()"
+    "# Run differential expression analysis.\n",
+    "# (only when not already in the Panel cache as this is a costly step\n",
+    "# we don't want every app visitor to pay)\n",
+    "if 'brca_ds_deseq2' in pn.state.cache:\n",
+    "    brca_ds = pn.state.cache['brca_ds_deseq2']\n",
+    "else:\n",
+    "    brca_ds.deseq2()\n",
+    "    pn.state.cache['brca_ds_deseq2'] = brca_ds"
    ]
   },
   {
@@ -596,14 +602,6 @@
     "\n",
     "This workflow was developed with support from NIH-NCI. TCGA data is provided by the National Cancer Institute Genomic Data Commons."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27891fc0-ab7d-4ce3-9f7d-26837c7739b5",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The anndata_diffex app is reported as failing quite often by the AE5 monitor lambda, adding noise to the Discord server. Let's see if caching this expensive step helps.