### PR TITLE
Disable read-only notebook deployments

### DIFF
--- a/anndata_diffex/anaconda-project.yml
+++ b/anndata_diffex/anaconda-project.yml
@@ -19,7 +19,6 @@ examples_config:
   # - Bioinformatics # maybe we should create this new category
   title: "Differential Expression in Bulk RNA-seq with AnnData"
   deployments:
-  - command: notebook
   - command: dashboard
   # no_data_ingestion: true
 

--- a/attractors/anaconda-project.yml
+++ b/attractors/anaconda-project.yml
@@ -17,7 +17,6 @@ examples_config:
   - numba
   - bokeh
   deployments:
-  - command: notebook
   - command: dashboard
 
 channels:

--- a/boids/anaconda-project.yml
+++ b/boids/anaconda-project.yml
@@ -11,8 +11,6 @@ examples_config:
   labels:
     - holoviews
     - bokeh
-  deployments:
-    - command: "notebook"
   no_data_ingestion: true
 
 user_fields: [examples_config]

--- a/census/anaconda-project.yml
+++ b/census/anaconda-project.yml
@@ -12,8 +12,6 @@ examples_config:
   - holoviews
   - dask
   - bokeh
-  deployments:
-  - command: notebook
   title: "Census 2010"
 
 

--- a/gene_profiling/anaconda-project.yml
+++ b/gene_profiling/anaconda-project.yml
@@ -17,7 +17,6 @@ examples_config:
   # - Bioinformatics # maybe we should create this new category
   title: "Gene Profiling of Cellular Subpopulations"
   deployments:
-  - command: notebook
   - command: dashboard
   no_data_ingestion: true
 

--- a/gerrymandering/anaconda-project.yml
+++ b/gerrymandering/anaconda-project.yml
@@ -15,8 +15,6 @@ examples_config:
   - bokeh
   - dask
   - geopandas
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/gull_tracking/anaconda-project.yml
+++ b/gull_tracking/anaconda-project.yml
@@ -12,8 +12,6 @@ examples_config:
   - datashader
   - hvplot
   - bokeh
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/hipster_dynamics/anaconda-project.yml
+++ b/hipster_dynamics/anaconda-project.yml
@@ -16,8 +16,6 @@ examples_config:
   - bokeh
   - matplotlib
   no_data_ingestion: true
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/iex_trading/anaconda-project.yml
+++ b/iex_trading/anaconda-project.yml
@@ -15,7 +15,6 @@ examples_config:
   notebooks_to_skip:
   - IEX_to_CSV.ipynb
   deployments:
-  - command: notebook
   - command: dashboard
 
 user_fields: [examples_config]

--- a/landsat/anaconda-project.yml
+++ b/landsat/anaconda-project.yml
@@ -14,8 +14,6 @@ examples_config:
   - datashader
   - numba
   - xarray
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/ml_annotators/anaconda-project.yml
+++ b/ml_annotators/anaconda-project.yml
@@ -13,8 +13,6 @@ examples_config:
   - geoviews
   - bokeh
   no_data_ingestion: true
-  # deployments:
-  # - command: notebook
 
 user_fields: [examples_config]
 

--- a/multichannel_timeseries/anaconda-project.yml
+++ b/multichannel_timeseries/anaconda-project.yml
@@ -19,7 +19,6 @@ examples_config:
   - Featured
   title: "Multichannel Timeseries"
   deployments:
-  # - command: notebook
   - command: dashboard
 
 user_fields: [examples_config]

--- a/nyc_buildings/anaconda-project.yml
+++ b/nyc_buildings/anaconda-project.yml
@@ -12,9 +12,6 @@ examples_config:
   - datashader
   - hvplot
   - spatialpandas
-  deployments:
-  - command: notebook
-  # - command: dashboard
 
 user_fields: [examples_config]
 

--- a/opensky/anaconda-project.yml
+++ b/opensky/anaconda-project.yml
@@ -14,8 +14,6 @@ examples_config:
   - bokeh
   - matplotlib
   - datashader
-  deployments:
-  - command: notebook
 
 channels: [defaults]
 

--- a/portfolio_optimizer/anaconda-project.yml
+++ b/portfolio_optimizer/anaconda-project.yml
@@ -14,7 +14,6 @@ examples_config:
   - holoviews
   - bokeh
   deployments:
-  - command: notebook
   - command: dashboard
 
 user_fields: [examples_config]

--- a/square_limit/anaconda-project.yml
+++ b/square_limit/anaconda-project.yml
@@ -12,8 +12,6 @@ examples_config:
   - holoviews
   - matplotlib
   no_data_ingestion: true
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/sri_model/anaconda-project.yml
+++ b/sri_model/anaconda-project.yml
@@ -14,8 +14,6 @@ examples_config:
   - param
   - networkx
   no_data_ingestion: true
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/timelapse_microscopy/anaconda-project.yml
+++ b/timelapse_microscopy/anaconda-project.yml
@@ -18,7 +18,6 @@ examples_config:
   - Neuroscience
   title: "Time-lapse Microscopy"
   deployments:
-  - command: notebook
   - command: dashboard
 
 user_fields: [examples_config]

--- a/uk_researchers/anaconda-project.yml
+++ b/uk_researchers/anaconda-project.yml
@@ -12,8 +12,6 @@ examples_config:
   - datashader
   - holoviews
   - bokeh
-  deployments:
-  - command: notebook
 
 user_fields: [examples_config]
 

--- a/world_cup/anaconda-project.yml
+++ b/world_cup/anaconda-project.yml
@@ -13,7 +13,6 @@ examples_config:
   - panel
   title: "FIFA World Cup 2018"
   deployments:
-  - command: notebook
   - command: dashboard
 
 user_fields: [examples_config]


### PR DESCRIPTION
Read-only notebook deployments were a nice feature of AE5 that isn't much maintained these days and is posing us a few problems (unstable cluster, requirement to add `notebook<7` to all the projects with such deployments). It's time to make our lives easier! (I also suspect notebook deployments weren't visited much but have no data to back this up).

Keeping only the `template` one to keep things running in case we need to bring some up in the future.