### PR TITLE
world_cup: download datasets from S3 holoviz

### DIFF
--- a/world_cup/anaconda-project.yml
+++ b/world_cup/anaconda-project.yml
@@ -40,11 +40,11 @@ commands:
 variables: {}
 downloads:
   DATA_1:
-    url: https://figshare.com/ndownloader/files/15073721
+    url: https://datasets.holoviz.org/soccer_match_event/v1/players.json
     description: Players dataset
     filename: data/players.json
   DATA_2:
-    url: https://figshare.com/ndownloader/files/14464685
+    url: https://datasets.holoviz.org/soccer_match_event/v1/events.zip
     description: Events dataset
     filename: data/events
     unzip: true


### PR DESCRIPTION
Apparently we can no longer directly download files from figshare (only from the browser or API). 