### PR TITLE
No longer deploy the template project as a notebook

### DIFF
--- a/template/anaconda-project.yml
+++ b/template/anaconda-project.yml
@@ -39,7 +39,7 @@ examples_config:
   # include "notebook" or "dashboard".
   deployments:
     # Will be deployed at {projname_with_hyphens}-notebook.holoviz-demo.anaconda.com
-  - command: notebook
+  # - command: notebook
     # Will be deployed at {projname_with_hyphens}.holoviz-demo.anaconda.com
   - command: dashboard
       # [OPTIONAL] Set the AE5 container resource profile.


### PR DESCRIPTION
The latest AE5 versions are likely to have broken/removed support for notebook deployments. It's time to let them go anyway!